### PR TITLE
Gemma Tutorials Added: TPU Inference and JAX based Data-Parallel Inference

### DIFF
--- a/Gemma/gemma_data_parallel_inference_in_jax_tpu.ipynb
+++ b/Gemma/gemma_data_parallel_inference_in_jax_tpu.ipynb
@@ -1,0 +1,3528 @@
+{
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "provenance": [],
+      "gpuType": "V28"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.14",
+      "mimetype": "text/x-python",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "kaggle": {
+      "accelerator": "tpu1vmV38",
+      "dataSources": [
+        {
+          "sourceId": 11350,
+          "sourceType": "modelInstanceVersion",
+          "modelInstanceId": 8367,
+          "modelId": 3301
+        },
+        {
+          "sourceId": 11371,
+          "sourceType": "modelInstanceVersion",
+          "modelInstanceId": 5171,
+          "modelId": 3533
+        },
+        {
+          "sourceId": 11375,
+          "sourceType": "modelInstanceVersion",
+          "modelInstanceId": 5172,
+          "modelId": 3533
+        }
+      ],
+      "dockerImageVersionId": 30698,
+      "isInternetEnabled": true,
+      "language": "python",
+      "sourceType": "notebook",
+      "isGpuEnabled": false
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "59e82a5d3ce54e0ebe009f8cc985f11b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_03e093d7ee3c49ca8ae6c7a3adec4241",
+              "IPY_MODEL_491431f44a42457b9f56a8c8cf06e18e",
+              "IPY_MODEL_c254302755fd41849b364b913167255f"
+            ],
+            "layout": "IPY_MODEL_4a5e6835a0ad42e6b09e0672a3187820"
+          }
+        },
+        "03e093d7ee3c49ca8ae6c7a3adec4241": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_8bfecef5f1c642e98fdaf4299e95de03",
+            "placeholder": "​",
+            "style": "IPY_MODEL_34184c816c444cb1904fcf9fa674bee8",
+            "value": "config.json: 100%"
+          }
+        },
+        "491431f44a42457b9f56a8c8cf06e18e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_3d19843e41cd424e9199ae1832b95948",
+            "max": 618,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_458a44ca8d48441ba572328e35bfa45b",
+            "value": 618
+          }
+        },
+        "c254302755fd41849b364b913167255f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_614c1c0fd6df4841bee24b48c6463725",
+            "placeholder": "​",
+            "style": "IPY_MODEL_ae8a28fa56254d749a4475cd8b5331c1",
+            "value": " 618/618 [00:00&lt;00:00, 52.1kB/s]"
+          }
+        },
+        "4a5e6835a0ad42e6b09e0672a3187820": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "8bfecef5f1c642e98fdaf4299e95de03": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "34184c816c444cb1904fcf9fa674bee8": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "3d19843e41cd424e9199ae1832b95948": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "458a44ca8d48441ba572328e35bfa45b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "614c1c0fd6df4841bee24b48c6463725": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "ae8a28fa56254d749a4475cd8b5331c1": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "2374e7a7e41b4bf58d3b620607f2103d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_2be0ad35da8e4b428ad87d5a369641e4",
+              "IPY_MODEL_1ec5d92ac698467abbd881f7cf0cb233",
+              "IPY_MODEL_56a21e1652c74943a44798f2917c9b36"
+            ],
+            "layout": "IPY_MODEL_d30c0c9139ed446097b184a0a49fb6b2"
+          }
+        },
+        "2be0ad35da8e4b428ad87d5a369641e4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_903024afc7034420a84fce14d09edff2",
+            "placeholder": "​",
+            "style": "IPY_MODEL_650ba2f470754e0bbeb6c913dd393d1a",
+            "value": "flax_model.msgpack: 100%"
+          }
+        },
+        "1ec5d92ac698467abbd881f7cf0cb233": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_c6d66b69c5c24a9f834b7bc8d5a94572",
+            "max": 5012352614,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_e18a2aa784554f28bbb64b7566c0538c",
+            "value": 5012352614
+          }
+        },
+        "56a21e1652c74943a44798f2917c9b36": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_48bd7e9c750e49439aeca2e3bc3ac60b",
+            "placeholder": "​",
+            "style": "IPY_MODEL_b3f871b1f292485fa5cf6a2b7d661bc6",
+            "value": " 5.01G/5.01G [02:06&lt;00:00, 38.7MB/s]"
+          }
+        },
+        "d30c0c9139ed446097b184a0a49fb6b2": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "903024afc7034420a84fce14d09edff2": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "650ba2f470754e0bbeb6c913dd393d1a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "c6d66b69c5c24a9f834b7bc8d5a94572": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "e18a2aa784554f28bbb64b7566c0538c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "48bd7e9c750e49439aeca2e3bc3ac60b": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "b3f871b1f292485fa5cf6a2b7d661bc6": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "6dabd5e1fe604820851293485f0d8dfa": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_dcfc1f944a664486ac7d9313d636b22f",
+              "IPY_MODEL_cc9d76debf1d4b31908d223ed4c500f8",
+              "IPY_MODEL_0856fac3697c4efdbb81b78ff63a9bfc"
+            ],
+            "layout": "IPY_MODEL_0ec8c6b7a93a4b9eb38d75ea91ad619d"
+          }
+        },
+        "dcfc1f944a664486ac7d9313d636b22f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_53c63250205443f695b47192e8c84cfe",
+            "placeholder": "​",
+            "style": "IPY_MODEL_79e7e1f70206405a9bb3a9c378530a0f",
+            "value": "generation_config.json: 100%"
+          }
+        },
+        "cc9d76debf1d4b31908d223ed4c500f8": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_63bd98967f644677812de0c0dc841a2b",
+            "max": 132,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_5a7e76b61c2f433e8586159348d2b021",
+            "value": 132
+          }
+        },
+        "0856fac3697c4efdbb81b78ff63a9bfc": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_4fb8ab98272b459db6dba91fd682ac6a",
+            "placeholder": "​",
+            "style": "IPY_MODEL_497589d5324c4fdc9f009a3dfaf29887",
+            "value": " 132/132 [00:00&lt;00:00, 13.8kB/s]"
+          }
+        },
+        "0ec8c6b7a93a4b9eb38d75ea91ad619d": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "53c63250205443f695b47192e8c84cfe": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "79e7e1f70206405a9bb3a9c378530a0f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "63bd98967f644677812de0c0dc841a2b": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "5a7e76b61c2f433e8586159348d2b021": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "4fb8ab98272b459db6dba91fd682ac6a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "497589d5324c4fdc9f009a3dfaf29887": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "3332ea7d742b461ea844c26d8e42f672": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_4097c942131942568e5268b388409a2c",
+              "IPY_MODEL_cf0b0da6773a4b54ae6b25980ed96273",
+              "IPY_MODEL_61f6c3eba15f479484b481e6230a5bb3"
+            ],
+            "layout": "IPY_MODEL_a6f7293c57a04ec58907eeb6196ad418"
+          }
+        },
+        "4097c942131942568e5268b388409a2c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_e42afd2d282349e1a422c96c5bfbf69b",
+            "placeholder": "​",
+            "style": "IPY_MODEL_e82b1395b34142598d8e779fe0b83aa2",
+            "value": "tokenizer_config.json: 100%"
+          }
+        },
+        "cf0b0da6773a4b54ae6b25980ed96273": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_592318c2facc4330bf296ac9799d6a09",
+            "max": 34173,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_915e4a42fd2a44c3b81e9590964ff82a",
+            "value": 34173
+          }
+        },
+        "61f6c3eba15f479484b481e6230a5bb3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6fd53f20c7834bcb8ba44d90d788d633",
+            "placeholder": "​",
+            "style": "IPY_MODEL_59f9b785b7c4436984a807cca5676601",
+            "value": " 34.2k/34.2k [00:00&lt;00:00, 3.06MB/s]"
+          }
+        },
+        "a6f7293c57a04ec58907eeb6196ad418": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "e42afd2d282349e1a422c96c5bfbf69b": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "e82b1395b34142598d8e779fe0b83aa2": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "592318c2facc4330bf296ac9799d6a09": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "915e4a42fd2a44c3b81e9590964ff82a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "6fd53f20c7834bcb8ba44d90d788d633": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "59f9b785b7c4436984a807cca5676601": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "9f42723a19c34b6ca395cc9391edcfe5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_de28816f7799412d8b6102dcf5e8bc1d",
+              "IPY_MODEL_f0ceb465384041e7b85f27a38e32d4b5",
+              "IPY_MODEL_eeeee196013a46e4b81a72584f8501e9"
+            ],
+            "layout": "IPY_MODEL_64173b0bfebc4ff180cf36b404fb944c"
+          }
+        },
+        "de28816f7799412d8b6102dcf5e8bc1d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_af85d4b47d8444318db72f434631ad1d",
+            "placeholder": "​",
+            "style": "IPY_MODEL_5d165b0b64ce4476bf200a0bf43caea5",
+            "value": "tokenizer.model: 100%"
+          }
+        },
+        "f0ceb465384041e7b85f27a38e32d4b5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_56fd385c9d064014b8d123edc885820c",
+            "max": 4241003,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_34c638399ab14b3ab4f54822dc33e92d",
+            "value": 4241003
+          }
+        },
+        "eeeee196013a46e4b81a72584f8501e9": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6cf69924d93c4c31a7a2525c3151a90a",
+            "placeholder": "​",
+            "style": "IPY_MODEL_7b659c798b7c4018b4d55118d6487a04",
+            "value": " 4.24M/4.24M [00:00&lt;00:00, 19.4MB/s]"
+          }
+        },
+        "64173b0bfebc4ff180cf36b404fb944c": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "af85d4b47d8444318db72f434631ad1d": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "5d165b0b64ce4476bf200a0bf43caea5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "56fd385c9d064014b8d123edc885820c": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "34c638399ab14b3ab4f54822dc33e92d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "6cf69924d93c4c31a7a2525c3151a90a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "7b659c798b7c4018b4d55118d6487a04": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "abdc6b6658bd4a15bc7a9622d26e440b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_678705792cb2495897946b6a5e7d7980",
+              "IPY_MODEL_9c75a2f81eb64468aa6d566d393e8973",
+              "IPY_MODEL_2a3170d5f79a43f5ac8ba0555738b31e"
+            ],
+            "layout": "IPY_MODEL_90325226317c4015b2ca2729408f20fa"
+          }
+        },
+        "678705792cb2495897946b6a5e7d7980": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_bc530027dd4f41ee8e47b05be73bc26d",
+            "placeholder": "​",
+            "style": "IPY_MODEL_437d3f6b11ff40e0b94263c6ec8142e0",
+            "value": "tokenizer.json: 100%"
+          }
+        },
+        "9c75a2f81eb64468aa6d566d393e8973": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_617e0b9bfb254cf0a0cb5eb2e00487de",
+            "max": 17518497,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_e82c180d96bf4840861ca2525e8d4163",
+            "value": 17518497
+          }
+        },
+        "2a3170d5f79a43f5ac8ba0555738b31e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_409182464e1c495fb80665466b1d1fc3",
+            "placeholder": "​",
+            "style": "IPY_MODEL_dcae339b945441588db96d970d52eb42",
+            "value": " 17.5M/17.5M [00:00&lt;00:00, 68.5MB/s]"
+          }
+        },
+        "90325226317c4015b2ca2729408f20fa": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "bc530027dd4f41ee8e47b05be73bc26d": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "437d3f6b11ff40e0b94263c6ec8142e0": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "617e0b9bfb254cf0a0cb5eb2e00487de": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "e82c180d96bf4840861ca2525e8d4163": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "409182464e1c495fb80665466b1d1fc3": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "dcae339b945441588db96d970d52eb42": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "87a5df6d22154d259d6aac4d1df904c6": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_594161a1e0fe4bcbb008ae8368f377c2",
+              "IPY_MODEL_a5cf9c9c55894bd280af9247bdfccb9c",
+              "IPY_MODEL_5a5f07dc96174404910f09b1173ef1fa"
+            ],
+            "layout": "IPY_MODEL_95643d2170d447ae88cab80b83c534ed"
+          }
+        },
+        "594161a1e0fe4bcbb008ae8368f377c2": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_c7319f732a17408c9d924fb9c0498580",
+            "placeholder": "​",
+            "style": "IPY_MODEL_1f8c82d01e4d4023839f2d91f56cd00f",
+            "value": "special_tokens_map.json: 100%"
+          }
+        },
+        "a5cf9c9c55894bd280af9247bdfccb9c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_a50a4de0a93849c0a5b3acae08ded535",
+            "max": 636,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_17b0a6744b64406fa84d4cc2de9547e7",
+            "value": 636
+          }
+        },
+        "5a5f07dc96174404910f09b1173ef1fa": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_b5d0cea921e44ada82e1b8189a500fc4",
+            "placeholder": "​",
+            "style": "IPY_MODEL_429f0b98aff141c19c617e592291292c",
+            "value": " 636/636 [00:00&lt;00:00, 63.1kB/s]"
+          }
+        },
+        "95643d2170d447ae88cab80b83c534ed": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "c7319f732a17408c9d924fb9c0498580": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1f8c82d01e4d4023839f2d91f56cd00f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "a50a4de0a93849c0a5b3acae08ded535": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "17b0a6744b64406fa84d4cc2de9547e7": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "b5d0cea921e44ada82e1b8189a500fc4": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "429f0b98aff141c19c617e592291292c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    }
+  },
+  "nbformat_minor": 0,
+  "nbformat": 4,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2024 Google LLC."
+      ],
+      "metadata": {
+        "id": "DQJauk8G0eXw"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "metadata": {
+        "cellView": "form",
+        "id": "B_NBCOPt0ipM"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Unlocking Gemma's Power: Data-Parallel Inference on TPUs with JAX"
+      ],
+      "metadata": {
+        "id": "QAFKDBS6L-bv"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/gemma-cookbook/blob/main/Gemma/gemma_inference_on_tpus.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "</table>"
+      ],
+      "metadata": {
+        "id": "IjHMo-YZN4-t"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Intro\n",
+        "\n",
+        "- This notebook demonstrates how to leverage [TPUs](https://www.kaggle.com/docs/tpu) and [JAX](https://jax.readthedocs.io/en/latest/) for **data-parallel inference** with the [Gemma](https://blog.google/technology/developers/gemma-open-models/) large language model.\n",
+        "\n",
+        "- We'll showcase its versatility by tackling various movie review tasks simultaneously within a single prompt. Imagine identifying key characters, summarizing plots, and classifying genres of a movie – all at blazing-fast speeds!\n",
+        "\n",
+        "- While this tutorial emphasizes movie reviews, the core concepts of data-parallel inference with Gemma extend to various real-world applications."
+      ],
+      "metadata": {
+        "id": "G6FSzFjJdkQ-"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## JAX Data Parallel Inference\n",
+        "\n",
+        "[JAX supports data parallelism](https://jax.readthedocs.io/en/latest/distributed_data_loading.html#data-parallelism) for efficient inference on multiple devices (TPUs, GPUs, etc.). In this approach, each device holds a replica of the model and processes a separate chunk of the input data (per-replica batch). This distribution reduces inference time for large datasets compared to running on a single device.\n",
+        "\n",
+        "**Key Points:**\n",
+        "- Each device has a copy of the model.\n",
+        "- Data is split into per-replica batches distributed across devices.\n",
+        "- JAX automatically handles data distribution, so you don't need to worry about the order in which data lands on each device.\n",
+        "This simplifies data loading: each device can independently receive its per-replica batch stream."
+      ],
+      "metadata": {
+        "id": "0d02FvvA0a67"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### **Let's get started!**"
+      ],
+      "metadata": {
+        "id": "4M2TSq9ByVjE"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Connect to a TPU:\n",
+        "- To connect to a TPU v2, click on the button Connect TPU in the top right-hand corner of the screen."
+      ],
+      "metadata": {
+        "id": "pcAAkx8LKaHy"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can now run the following code cell to see the TPU devices we have available:"
+      ],
+      "metadata": {
+        "id": "LXUWFVxV8gTI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import jax\n",
+        "\n",
+        "jax.local_devices()"
+      ],
+      "metadata": {
+        "id": "1XWpUuCgo7kd",
+        "outputId": "d6059b74-f618-44a0-8288-fff157a9645e",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:19.368783Z",
+          "iopub.execute_input": "2024-07-19T21:03:19.369196Z",
+          "iopub.status.idle": "2024-07-19T21:03:19.375497Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:19.369161Z",
+          "shell.execute_reply": "2024-07-19T21:03:19.374452Z"
+        },
+        "trusted": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0),\n",
+              " TpuDevice(id=1, process_index=0, coords=(0,0,0), core_on_chip=1),\n",
+              " TpuDevice(id=2, process_index=0, coords=(1,0,0), core_on_chip=0),\n",
+              " TpuDevice(id=3, process_index=0, coords=(1,0,0), core_on_chip=1),\n",
+              " TpuDevice(id=4, process_index=0, coords=(0,1,0), core_on_chip=0),\n",
+              " TpuDevice(id=5, process_index=0, coords=(0,1,0), core_on_chip=1),\n",
+              " TpuDevice(id=6, process_index=0, coords=(1,1,0), core_on_chip=0),\n",
+              " TpuDevice(id=7, process_index=0, coords=(1,1,0), core_on_chip=1)]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 1
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Awesome! Our setup includes a TPU with 8 cores. This notebook will take advantage of this by splitting our workload across all cores (data parallelism). Each core will receive a fraction of the data (1/8th) and generate results simultaneously."
+      ],
+      "metadata": {
+        "id": "dDjG76wZOvCb"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Import libraries"
+      ],
+      "metadata": {
+        "id": "Sy2EwL0x8gTK"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "import numpy as np\n",
+        "from flax import jax_utils\n",
+        "from flax.training.common_utils import shard\n",
+        "from transformers import FlaxGemmaForCausalLM, AutoTokenizer"
+      ],
+      "metadata": {
+        "id": "LjQ4e57vmWCP",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:21.636517Z",
+          "iopub.execute_input": "2024-07-19T21:03:21.636894Z",
+          "iopub.status.idle": "2024-07-19T21:03:21.641462Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:21.636865Z",
+          "shell.execute_reply": "2024-07-19T21:03:21.640513Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 26,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## How to Access Gemma:\n",
+        "\n",
+        "Before using Gemma for the first time, you need to request access to the model through [Hugging Face](https://huggingface.co/google/gemma-2b). This ensures you've accepted the model's terms-of-use.\n",
+        "\n",
+        "Since we'll be downloading the Gemma model weights from the Hugging Face Hub, you'll need a Hugging Face token to verify your acceptance.\n",
+        "\n",
+        "If you don't already have a Hugging Face account, you can register for one at [Hugging Face](https://huggingface.co/join). Once you have an account, follow these steps:\n",
+        "\n",
+        "1. Go to the [Hugging Face Gemma Model Card](https://huggingface.co/google/gemma-2b) and select Request Access.\n",
+        "2. Complete the consent form and accept the terms and conditions.\n",
+        "3. Go to [Hugging Face Hub account settings](https://huggingface.co/settings/tokens) and create a new access token.\n",
+        "3. Copy your Token.\n",
+        "4. Then, in Colab, select **Secrets** (🔑) in the left pane and add your Token name (choose a secure name like `hugging_face_token_key`) and store your Token value under that name."
+      ],
+      "metadata": {
+        "id": "DRqIBQOmA7Nc"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from google.colab import userdata\n",
+        "import os\n",
+        "\n",
+        "try:\n",
+        "    access_token = userdata.get('hugging_face_token_key')\n",
+        "except ImportError:\n",
+        "    access_token = os.environ['hugging_face_token_key']"
+      ],
+      "metadata": {
+        "id": "qE4YuCo-8gTL",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:22.571542Z",
+          "iopub.execute_input": "2024-07-19T21:03:22.572199Z",
+          "iopub.status.idle": "2024-07-19T21:03:22.708276Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:22.572165Z",
+          "shell.execute_reply": "2024-07-19T21:03:22.707224Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Load the Model\n",
+        "We will use the latest [Gemma-2B](https://huggingface.co/google/gemma-1.1-2b-it), this model offers 2 billion parameters, ensuring a lightweight footprint.\n",
+        "\n",
+        "The Gemma model can be loaded using the familiar [`from_pretrained`](https://huggingface.co/docs/transformers/v4.38.1/en/main_classes/model#transformers.FlaxPreTrainedModel.from_pretrained) method in Transformers. This method downloads the model weights from the Hugging Face Hub the first time it is called, and subsequently intialises the Gemma model using these weights.\n"
+      ],
+      "metadata": {
+        "id": "Rb2VBFGJQ1yx"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# We will use the latest Gemma 1.1 2B (IT), an update over the original instruction-tuned Gemma release.\n",
+        "model_id = \"google/gemma-1.1-2b-it\"\n",
+        "\n",
+        "# Load the model with desired data type (bfloat16 for reduced memory usage)\n",
+        "model, params = FlaxGemmaForCausalLM.from_pretrained(model_id, revision=\"flax\", _do_init=False, dtype=jnp.bfloat16, token=access_token)"
+      ],
+      "metadata": {
+        "id": "KMHP_dDD8gTL",
+        "outputId": "695d3f24-b2e2-45fd-f225-ebdf57bbdda2",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:23.550278Z",
+          "iopub.execute_input": "2024-07-19T21:03:23.550665Z",
+          "iopub.status.idle": "2024-07-19T21:03:34.865655Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:23.550632Z",
+          "shell.execute_reply": "2024-07-19T21:03:34.864670Z"
+        },
+        "trusted": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 289,
+          "referenced_widgets": [
+            "59e82a5d3ce54e0ebe009f8cc985f11b",
+            "03e093d7ee3c49ca8ae6c7a3adec4241",
+            "491431f44a42457b9f56a8c8cf06e18e",
+            "c254302755fd41849b364b913167255f",
+            "4a5e6835a0ad42e6b09e0672a3187820",
+            "8bfecef5f1c642e98fdaf4299e95de03",
+            "34184c816c444cb1904fcf9fa674bee8",
+            "3d19843e41cd424e9199ae1832b95948",
+            "458a44ca8d48441ba572328e35bfa45b",
+            "614c1c0fd6df4841bee24b48c6463725",
+            "ae8a28fa56254d749a4475cd8b5331c1",
+            "2374e7a7e41b4bf58d3b620607f2103d",
+            "2be0ad35da8e4b428ad87d5a369641e4",
+            "1ec5d92ac698467abbd881f7cf0cb233",
+            "56a21e1652c74943a44798f2917c9b36",
+            "d30c0c9139ed446097b184a0a49fb6b2",
+            "903024afc7034420a84fce14d09edff2",
+            "650ba2f470754e0bbeb6c913dd393d1a",
+            "c6d66b69c5c24a9f834b7bc8d5a94572",
+            "e18a2aa784554f28bbb64b7566c0538c",
+            "48bd7e9c750e49439aeca2e3bc3ac60b",
+            "b3f871b1f292485fa5cf6a2b7d661bc6",
+            "6dabd5e1fe604820851293485f0d8dfa",
+            "dcfc1f944a664486ac7d9313d636b22f",
+            "cc9d76debf1d4b31908d223ed4c500f8",
+            "0856fac3697c4efdbb81b78ff63a9bfc",
+            "0ec8c6b7a93a4b9eb38d75ea91ad619d",
+            "53c63250205443f695b47192e8c84cfe",
+            "79e7e1f70206405a9bb3a9c378530a0f",
+            "63bd98967f644677812de0c0dc841a2b",
+            "5a7e76b61c2f433e8586159348d2b021",
+            "4fb8ab98272b459db6dba91fd682ac6a",
+            "497589d5324c4fdc9f009a3dfaf29887"
+          ]
+        }
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_token.py:89: UserWarning: \n",
+            "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
+            "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
+            "You will be able to reuse this secret in all of your notebooks.\n",
+            "Please note that authentication is recommended but still optional to access public models or datasets.\n",
+            "  warnings.warn(\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "config.json:   0%|          | 0.00/618 [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "59e82a5d3ce54e0ebe009f8cc985f11b"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "flax_model.msgpack:   0%|          | 0.00/5.01G [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "2374e7a7e41b4bf58d3b620607f2103d"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "Some of the weights of FlaxGemmaForCausalLM were initialized in bfloat16 precision from the model checkpoint at google/gemma-1.1-2b-it:\n",
+            "[('model', 'embed_tokens', 'embedding'), ('model', 'layers', '0', 'input_layernorm', 'weight'), ('model', 'layers', '0', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '0', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '0', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '0', 'post_attention_layernorm', 'weight'), ('model', 'layers', '0', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '0', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '0', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '0', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '1', 'input_layernorm', 'weight'), ('model', 'layers', '1', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '1', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '1', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '1', 'post_attention_layernorm', 'weight'), ('model', 'layers', '1', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '1', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '1', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '1', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '10', 'input_layernorm', 'weight'), ('model', 'layers', '10', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '10', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '10', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '10', 'post_attention_layernorm', 'weight'), ('model', 'layers', '10', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '10', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '10', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '10', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '11', 'input_layernorm', 'weight'), ('model', 'layers', '11', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '11', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '11', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '11', 'post_attention_layernorm', 'weight'), ('model', 'layers', '11', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '11', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '11', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '11', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '12', 'input_layernorm', 'weight'), ('model', 'layers', '12', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '12', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '12', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '12', 'post_attention_layernorm', 'weight'), ('model', 'layers', '12', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '12', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '12', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '12', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '13', 'input_layernorm', 'weight'), ('model', 'layers', '13', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '13', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '13', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '13', 'post_attention_layernorm', 'weight'), ('model', 'layers', '13', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '13', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '13', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '13', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '14', 'input_layernorm', 'weight'), ('model', 'layers', '14', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '14', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '14', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '14', 'post_attention_layernorm', 'weight'), ('model', 'layers', '14', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '14', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '14', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '14', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '15', 'input_layernorm', 'weight'), ('model', 'layers', '15', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '15', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '15', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '15', 'post_attention_layernorm', 'weight'), ('model', 'layers', '15', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '15', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '15', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '15', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '16', 'input_layernorm', 'weight'), ('model', 'layers', '16', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '16', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '16', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '16', 'post_attention_layernorm', 'weight'), ('model', 'layers', '16', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '16', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '16', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '16', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '17', 'input_layernorm', 'weight'), ('model', 'layers', '17', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '17', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '17', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '17', 'post_attention_layernorm', 'weight'), ('model', 'layers', '17', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '17', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '17', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '17', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '2', 'input_layernorm', 'weight'), ('model', 'layers', '2', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '2', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '2', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '2', 'post_attention_layernorm', 'weight'), ('model', 'layers', '2', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '2', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '2', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '2', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '3', 'input_layernorm', 'weight'), ('model', 'layers', '3', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '3', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '3', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '3', 'post_attention_layernorm', 'weight'), ('model', 'layers', '3', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '3', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '3', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '3', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '4', 'input_layernorm', 'weight'), ('model', 'layers', '4', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '4', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '4', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '4', 'post_attention_layernorm', 'weight'), ('model', 'layers', '4', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '4', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '4', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '4', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '5', 'input_layernorm', 'weight'), ('model', 'layers', '5', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '5', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '5', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '5', 'post_attention_layernorm', 'weight'), ('model', 'layers', '5', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '5', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '5', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '5', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '6', 'input_layernorm', 'weight'), ('model', 'layers', '6', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '6', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '6', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '6', 'post_attention_layernorm', 'weight'), ('model', 'layers', '6', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '6', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '6', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '6', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '7', 'input_layernorm', 'weight'), ('model', 'layers', '7', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '7', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '7', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '7', 'post_attention_layernorm', 'weight'), ('model', 'layers', '7', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '7', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '7', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '7', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '8', 'input_layernorm', 'weight'), ('model', 'layers', '8', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '8', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '8', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '8', 'post_attention_layernorm', 'weight'), ('model', 'layers', '8', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '8', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '8', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '8', 'self_attn', 'v_proj', 'kernel'), ('model', 'layers', '9', 'input_layernorm', 'weight'), ('model', 'layers', '9', 'mlp', 'down_proj', 'kernel'), ('model', 'layers', '9', 'mlp', 'gate_proj', 'kernel'), ('model', 'layers', '9', 'mlp', 'up_proj', 'kernel'), ('model', 'layers', '9', 'post_attention_layernorm', 'weight'), ('model', 'layers', '9', 'self_attn', 'k_proj', 'kernel'), ('model', 'layers', '9', 'self_attn', 'o_proj', 'kernel'), ('model', 'layers', '9', 'self_attn', 'q_proj', 'kernel'), ('model', 'layers', '9', 'self_attn', 'v_proj', 'kernel'), ('model', 'norm', 'weight')]\n",
+            "You should probably UPCAST the model weights to float32 if this was not intended. See [`~FlaxPreTrainedModel.to_fp32`] for further information on how to do this.\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "generation_config.json:   0%|          | 0.00/132 [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "6dabd5e1fe604820851293485f0d8dfa"
+            }
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We see a warning that the model parameters were loaded in bfloat16 precision - this is fine since we also want to keep the parameters in bfloat16 for inference."
+      ],
+      "metadata": {
+        "id": "8nSmjYj88gTM"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The corresponding tokenizer can now be loaded using a similar API:"
+      ],
+      "metadata": {
+        "id": "GQMjMGOLeHF_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "tokenizer = AutoTokenizer.from_pretrained(model_id, token=access_token)"
+      ],
+      "metadata": {
+        "id": "SOgY8-DroH4y",
+        "outputId": "18bfe7e5-5d6a-4d9e-c47c-6715e0392087",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:34.867434Z",
+          "iopub.execute_input": "2024-07-19T21:03:34.867690Z",
+          "iopub.status.idle": "2024-07-19T21:03:35.815241Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:34.867664Z",
+          "shell.execute_reply": "2024-07-19T21:03:35.814201Z"
+        },
+        "trusted": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 145,
+          "referenced_widgets": [
+            "3332ea7d742b461ea844c26d8e42f672",
+            "4097c942131942568e5268b388409a2c",
+            "cf0b0da6773a4b54ae6b25980ed96273",
+            "61f6c3eba15f479484b481e6230a5bb3",
+            "a6f7293c57a04ec58907eeb6196ad418",
+            "e42afd2d282349e1a422c96c5bfbf69b",
+            "e82b1395b34142598d8e779fe0b83aa2",
+            "592318c2facc4330bf296ac9799d6a09",
+            "915e4a42fd2a44c3b81e9590964ff82a",
+            "6fd53f20c7834bcb8ba44d90d788d633",
+            "59f9b785b7c4436984a807cca5676601",
+            "9f42723a19c34b6ca395cc9391edcfe5",
+            "de28816f7799412d8b6102dcf5e8bc1d",
+            "f0ceb465384041e7b85f27a38e32d4b5",
+            "eeeee196013a46e4b81a72584f8501e9",
+            "64173b0bfebc4ff180cf36b404fb944c",
+            "af85d4b47d8444318db72f434631ad1d",
+            "5d165b0b64ce4476bf200a0bf43caea5",
+            "56fd385c9d064014b8d123edc885820c",
+            "34c638399ab14b3ab4f54822dc33e92d",
+            "6cf69924d93c4c31a7a2525c3151a90a",
+            "7b659c798b7c4018b4d55118d6487a04",
+            "abdc6b6658bd4a15bc7a9622d26e440b",
+            "678705792cb2495897946b6a5e7d7980",
+            "9c75a2f81eb64468aa6d566d393e8973",
+            "2a3170d5f79a43f5ac8ba0555738b31e",
+            "90325226317c4015b2ca2729408f20fa",
+            "bc530027dd4f41ee8e47b05be73bc26d",
+            "437d3f6b11ff40e0b94263c6ec8142e0",
+            "617e0b9bfb254cf0a0cb5eb2e00487de",
+            "e82c180d96bf4840861ca2525e8d4163",
+            "409182464e1c495fb80665466b1d1fc3",
+            "dcae339b945441588db96d970d52eb42",
+            "87a5df6d22154d259d6aac4d1df904c6",
+            "594161a1e0fe4bcbb008ae8368f377c2",
+            "a5cf9c9c55894bd280af9247bdfccb9c",
+            "5a5f07dc96174404910f09b1173ef1fa",
+            "95643d2170d447ae88cab80b83c534ed",
+            "c7319f732a17408c9d924fb9c0498580",
+            "1f8c82d01e4d4023839f2d91f56cd00f",
+            "a50a4de0a93849c0a5b3acae08ded535",
+            "17b0a6744b64406fa84d4cc2de9547e7",
+            "b5d0cea921e44ada82e1b8189a500fc4",
+            "429f0b98aff141c19c617e592291292c"
+          ]
+        }
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "tokenizer_config.json:   0%|          | 0.00/34.2k [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "3332ea7d742b461ea844c26d8e42f672"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "tokenizer.model:   0%|          | 0.00/4.24M [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "9f42723a19c34b6ca395cc9391edcfe5"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "tokenizer.json:   0%|          | 0.00/17.5M [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "abdc6b6658bd4a15bc7a9622d26e440b"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "special_tokens_map.json:   0%|          | 0.00/636 [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "87a5df6d22154d259d6aac4d1df904c6"
+            }
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Define Inputs\n",
+        "\n",
+        "Next, we'll define our text inputs. Since we have 8 TPU cores over which we want to perform data parallelism, we need our batch size to be a multiple of 8. This is to ensure that each TPU core receives the same amount of data (`bsz / 8` samples). We will change the input text later."
+      ],
+      "metadata": {
+        "id": "BVz3ylFwepfU"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "input_text = 8 * [\"What year was the movie Titanic made?\"]"
+      ],
+      "metadata": {
+        "id": "-XciqMHmsQqE",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:35.816651Z",
+          "iopub.execute_input": "2024-07-19T21:03:35.816918Z",
+          "iopub.status.idle": "2024-07-19T21:03:35.820744Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:35.816892Z",
+          "shell.execute_reply": "2024-07-19T21:03:35.819893Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can pre-process our input text to token ids using the tokenizer. TPUs expect inputs of static shape, so we'll define our maximum prompt length to be 64, and always pad our inputs to this sequence length:"
+      ],
+      "metadata": {
+        "id": "QuePjDn6sO3_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "max_input_length = 64\n",
+        "\n",
+        "inputs = tokenizer(\n",
+        "    input_text,\n",
+        "    padding=\"max_length\",\n",
+        "    max_length=max_input_length,\n",
+        "    return_attention_mask=True,\n",
+        "    return_tensors=\"np\",\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "X9a5KeFUoE6_",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:35.822597Z",
+          "iopub.execute_input": "2024-07-19T21:03:35.822857Z",
+          "iopub.status.idle": "2024-07-19T21:03:35.834175Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:35.822831Z",
+          "shell.execute_reply": "2024-07-19T21:03:35.833355Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We now need to copy the model parameters to each TPU core. Each core will hold it's own copy of the parameters, such that it can run a model generation in parallel with the others. Copying the parameters across devices is achieved simply with the [`replicate`](https://flax.readthedocs.io/en/latest/api_reference/flax.jax_utils.html#flax.jax_utils.replicate) method from Flax."
+      ],
+      "metadata": {
+        "id": "eW3iFWNeUAxX"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "params = jax_utils.replicate(params)"
+      ],
+      "metadata": {
+        "id": "aMA1qL-5ofwq",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:35.835230Z",
+          "iopub.execute_input": "2024-07-19T21:03:35.835541Z",
+          "iopub.status.idle": "2024-07-19T21:03:35.909133Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:35.835513Z",
+          "shell.execute_reply": "2024-07-19T21:03:35.906919Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Similarly, we need to split (or shard) our inputs across TPU cores. Sharding our inputs is achieved with the Flax helper function [`shard`](https://flax.readthedocs.io/en/latest/api_reference/flax.training.html#flax.training.common_utils.shard):"
+      ],
+      "metadata": {
+        "id": "Xaygh3WvUh0G"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "inputs = shard(inputs.data)"
+      ],
+      "metadata": {
+        "id": "yEUlaMepUi1M",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:35.910648Z",
+          "iopub.execute_input": "2024-07-19T21:03:35.911088Z",
+          "iopub.status.idle": "2024-07-19T21:03:35.918313Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:35.911022Z",
+          "shell.execute_reply": "2024-07-19T21:03:35.915687Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Inference\n",
+        "\n",
+        "We can now define our data-parallel method for inference. The Transformers [`generate`](https://huggingface.co/docs/transformers/v4.38.1/en/main_classes/text_generation#transformers.FlaxGenerationMixin.generate) method provides functionality for auto-regressive generation with batching, sampling, beam-search, etc. To reap the benefits of JAX, we'll compile the generate method end-to-end, such that the operations are fused into XLA-optimised kernels and executed efficiently on our hardware accelerator.\n",
+        "\n",
+        "To achieve this, we'll wrap the `generate` method with the [`jax.pmap`](https://jax.readthedocs.io/en/latest/_autosummary/jax.pmap.html) transformation. The `jax.pmap` transformation compiles the `generate` method with XLA, and prepares a function that can be executed in parallel across TPU devices."
+      ],
+      "metadata": {
+        "id": "Qfb-MXRPUZY5"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def generate(inputs, params, max_new_tokens):\n",
+        "    generated_ids = model.generate(\n",
+        "        inputs[\"input_ids\"],\n",
+        "        attention_mask=inputs[\"attention_mask\"],\n",
+        "        params=params,\n",
+        "        max_new_tokens=max_new_tokens,\n",
+        "        do_sample=True,\n",
+        "    )\n",
+        "    return generated_ids.sequences\n",
+        "\n",
+        "p_generate = jax.pmap(\n",
+        "    generate, \"inputs\", in_axes=(0, 0, None,), out_axes=0, static_broadcasted_argnums=(2,)\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "tOE2UjXqUZvi",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:35.920730Z",
+          "iopub.execute_input": "2024-07-19T21:03:35.921075Z",
+          "iopub.status.idle": "2024-07-19T21:03:35.963883Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:35.921038Z",
+          "shell.execute_reply": "2024-07-19T21:03:35.962630Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "To avoid re-compiling the generate function for different values of `max_new_tokens`, we'll define it as a global variable here, and pass it to the generate function each time:"
+      ],
+      "metadata": {
+        "id": "cepVL9tne2jg"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "max_new_tokens = 128"
+      ],
+      "metadata": {
+        "id": "uVf9xbJBoYUG",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:35.965784Z",
+          "iopub.execute_input": "2024-07-19T21:03:35.966080Z",
+          "iopub.status.idle": "2024-07-19T21:03:35.983202Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:35.966045Z",
+          "shell.execute_reply": "2024-07-19T21:03:35.982215Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can now compile our parallel generate function."
+      ],
+      "metadata": {
+        "id": "eTC7I3bmWXgL"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "_ = p_generate(inputs, params, max_new_tokens)"
+      ],
+      "metadata": {
+        "id": "Ws1XC2PGHBYu",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:35.984259Z",
+          "iopub.execute_input": "2024-07-19T21:03:35.984586Z",
+          "iopub.status.idle": "2024-07-19T21:03:50.524529Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:35.984555Z",
+          "shell.execute_reply": "2024-07-19T21:03:50.523350Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now that the function is compiled, we can run it again much faster using the optimised kernels:"
+      ],
+      "metadata": {
+        "id": "XYxnfADQWqxs"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "generated_ids = p_generate(inputs, params, max_new_tokens)"
+      ],
+      "metadata": {
+        "id": "g1JbDhJQmh_w",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:50.526725Z",
+          "iopub.execute_input": "2024-07-19T21:03:50.527000Z",
+          "iopub.status.idle": "2024-07-19T21:03:50.533162Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:50.526973Z",
+          "shell.execute_reply": "2024-07-19T21:03:50.532232Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "After generate function compiled, the model outputs token IDs, which are then decoded by the tokenizer back into human-readable text:"
+      ],
+      "metadata": {
+        "id": "qDOUrhKMW2cT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "generated_ids = jax.device_get(generated_ids.reshape(-1, generated_ids.shape[-1]))\n",
+        "pred_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)"
+      ],
+      "metadata": {
+        "id": "z-bUqMoJs6t1",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:03:50.534186Z",
+          "iopub.execute_input": "2024-07-19T21:03:50.534471Z",
+          "iopub.status.idle": "2024-07-19T21:03:51.105975Z",
+          "shell.execute_reply.started": "2024-07-19T21:03:50.534443Z",
+          "shell.execute_reply": "2024-07-19T21:03:51.104880Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Analyze Movie Reviews with Parallel Processing on TPUs\n",
+        "\n",
+        "This code demonstrates analyzing film critiques using multiple tasks processed concurrently on TPUs. The model performs the following tasks on each movie review:\n",
+        "\n",
+        "* **Identify Key Characters:** Find the two main characters in the film.\n",
+        "* **Summarize Plot:** Briefly condense the story's key points.\n",
+        "* **Predict Genre:** Classify the film genre based on the critique (e.g., comedy, drama).\n",
+        "* **Recommend Similar Films:** Suggest two films with similar titles or themes.\n",
+        "\n",
+        "**Parallel Processing Power:**\n",
+        "\n",
+        "This approach leverages all available TPU cores to analyze multiple movies and tasks simultaneously. This significantly speeds up the analysis compared to processing each movie and task sequentially."
+      ],
+      "metadata": {
+        "id": "Axw6Aqla0a7B"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Creates formatted input text for multiple movies and tasks.\n",
+        "def create_movie_inputs(movie_titles, tasks):\n",
+        "  \"\"\"\n",
+        " Args:\n",
+        "    movie_titles: List of movie titles with optional year information.\n",
+        "    tasks: List of task descriptions with emphasized objectives.\n",
+        "\n",
+        "  Returns:\n",
+        "    A list of formatted input text for the model.\n",
+        "  \"\"\"\n",
+        "  inputs = []\n",
+        "  for title in movie_titles:\n",
+        "    for task in tasks:\n",
+        "      formatted_task = f\"\\n**Task:** {task}\\n=============\"\n",
+        "      inputs.append(f\"\\n=============**Movie Title:**{title}{formatted_task}\")\n",
+        "  return inputs"
+      ],
+      "metadata": {
+        "id": "hJyX1-bw8gTP",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:04:13.245694Z",
+          "iopub.execute_input": "2024-07-19T21:04:13.246064Z",
+          "iopub.status.idle": "2024-07-19T21:04:13.251167Z",
+          "shell.execute_reply.started": "2024-07-19T21:04:13.246034Z",
+          "shell.execute_reply": "2024-07-19T21:04:13.250351Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Define movie titles with optional year information\n",
+        "movie_titles = [\"Titanic (1997 film)\", \"Avatar (2009 film)\"]\n",
+        "\n",
+        "# Define tasks to be performed for each movie (one prompt per task)\n",
+        "tasks = [\n",
+        "    \"Main Characters (2 max): Who are the 2 key characters?\",\n",
+        "    \"Plot Summary (1 sentence): Briefly summarize the story.\",\n",
+        "    \"Genre: What is the most likely genre (e.g. science fiction, comedy, drama)?\",\n",
+        "    \"Recommendation: Suggest 2 movies with similar titles or themes.\"\n",
+        "]"
+      ],
+      "metadata": {
+        "id": "j9Ygu1eZ8gTQ",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:02:53.910452Z",
+          "iopub.execute_input": "2024-07-19T21:02:53.910799Z",
+          "iopub.status.idle": "2024-07-19T21:02:53.915548Z",
+          "shell.execute_reply.started": "2024-07-19T21:02:53.910769Z",
+          "shell.execute_reply": "2024-07-19T21:02:53.914565Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 21,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Create formatted input text for the model, combining movie titles and tasks\n",
+        "input_text = create_movie_inputs(movie_titles, tasks)\n",
+        "\n",
+        "# Tokenize the input text for the model using the provided tokenizer\n",
+        "inputs = tokenizer(input_text, padding=\"max_length\", max_length=max_input_length, return_attention_mask=True, return_tensors=\"np\")\n",
+        "\n",
+        "# Shard the inputs for data parallelism across multiple TPUs\n",
+        "inputs = shard(inputs.data)\n",
+        "\n",
+        "# Get the generated IDs back from the TPU device and reshape\n",
+        "generated_ids = p_generate(inputs, params, max_new_tokens)\n",
+        "generated_ids = jax.device_get(generated_ids.reshape(-1, generated_ids.shape[-1]))\n",
+        "\n",
+        "# Decode the generated IDs back into text using the tokenizer\n",
+        "pred_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)\n"
+      ],
+      "metadata": {
+        "id": "vDgtekfC2_pY",
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:02:54.266331Z",
+          "iopub.execute_input": "2024-07-19T21:02:54.266726Z",
+          "iopub.status.idle": "2024-07-19T21:02:55.362131Z",
+          "shell.execute_reply.started": "2024-07-19T21:02:54.266694Z",
+          "shell.execute_reply": "2024-07-19T21:02:55.361039Z"
+        },
+        "trusted": true
+      },
+      "execution_count": 22,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, the model has finished its predictions using all 8 TPU cores. Let's see what it generated for each task and each movie."
+      ],
+      "metadata": {
+        "id": "Gvqg1Ens8gTQ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "for i in range(4):  # First movie\n",
+        "    print(pred_text[i])"
+      ],
+      "metadata": {
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:02:55.363674Z",
+          "iopub.execute_input": "2024-07-19T21:02:55.363941Z",
+          "iopub.status.idle": "2024-07-19T21:02:55.368632Z",
+          "shell.execute_reply.started": "2024-07-19T21:02:55.363916Z",
+          "shell.execute_reply": "2024-07-19T21:02:55.367692Z"
+        },
+        "trusted": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "oC4hMvvs0a7H",
+        "outputId": "62a8b07d-6930-4188-f104-9c639d9d5828"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "=============**Movie Title:**Titanic (1997 film)\n",
+            "**Task:Main Characters (2 max): Who are the 2 key characters?\n",
+            "=============**\n",
+            "\n",
+            "In the movie Titanic (1997), there are two key characters that drive the plot forward: Jack Dawson and Rose DeWitt Bukater. Jack is a charming and wealthy young man from a poor background who dreams of escaping his humble life and achieving greatness. Rose is a strong-willed and independent young woman who represents the aspirations and resilience of women in the 19th century.\n",
+            "\n",
+            "=============**Movie Title:**Titanic (1997 film)\n",
+            "**Task:Plot Summary (1 sentence): Briefly summarize the story.\n",
+            "=============**\n",
+            "\n",
+            "In the year 1997, James Cameron crafts a tale of love, loss, and survival aboard the luxurious cruise ship RMS Titanic. With its opulent grand staircase, lavish cabins, and doomed romance, the film explores themes of class distinction, human capacity, and the fragility of life.\n",
+            "\n",
+            "=============**Movie Title:**Titanic (1997 film)\n",
+            "**Task:Genre: What is the most likely genre (e.g. science fiction, comedy, drama)?\n",
+            "=============**\n",
+            "\n",
+            "The provided text suggests that the genre of the movie Titanic (1997) is likely to be **drama**.\n",
+            "\n",
+            "=============**Movie Title:**Titanic (1997 film)\n",
+            "**Task:Recommendation: Suggest 2 movies with similar titles or themes.\n",
+            "=============**\n",
+            "\n",
+            "**Movie 1:** The Wolf of Wall Street (2013)\n",
+            "**Movie 2:** The Greatest Showman (2017)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "for i in range(4):  # Second movie\n",
+        "    print(pred_text[i+4])"
+      ],
+      "metadata": {
+        "execution": {
+          "iopub.status.busy": "2024-07-19T21:02:55.552731Z",
+          "iopub.execute_input": "2024-07-19T21:02:55.553712Z",
+          "iopub.status.idle": "2024-07-19T21:02:55.558342Z",
+          "shell.execute_reply.started": "2024-07-19T21:02:55.553674Z",
+          "shell.execute_reply": "2024-07-19T21:02:55.557337Z"
+        },
+        "trusted": true,
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "toeMIcG90a7H",
+        "outputId": "9721533b-5c1c-4f60-c7b8-144c3f01257f"
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "=============**Movie Title:**Avatar (2009 film)\n",
+            "**Task:Main Characters (2 max): Who are the 2 key characters?\n",
+            "=============**\n",
+            "\n",
+            "The main characters of the 2009 film Avatar are Jake Sully and Neytiri.\n",
+            "\n",
+            "=============**Movie Title:**Avatar (2009 film)\n",
+            "**Task:Plot Summary (1 sentence): Briefly summarize the story.\n",
+            "=============**\n",
+            "\n",
+            "In the distant future, Jake Sully and his team of explorers travel to a remote planet called Pandora in search of the native species, the Na'vi. Guided by Neytiri, the Na'vi leader, they soon discover the planet's natural resources are being exploited. In the ensuing battle between colonization and preservation, Jake and Neytiri must make a choice that will determine the fate of Pandora.\n",
+            "\n",
+            "=============**Movie Title:**Avatar (2009 film)\n",
+            "**Task:Genre: What is the most likely genre (e.g. science fiction, comedy, drama)?\n",
+            "=============**\n",
+            "\n",
+            "The genre of the movie Avatar (2009) is most likely science fiction.\n",
+            "\n",
+            "The movie deals with themes of environmentalism, colonization, and the relationships between humans and nature. It also features advanced technology and special effects that are characteristic of science fiction.\n",
+            "\n",
+            "=============**Movie Title:**Avatar (2009 film)\n",
+            "**Task:Recommendation: Suggest 2 movies with similar titles or themes.\n",
+            "=============**\n",
+            "\n",
+            "**Movie 1:** The Curious Case of Benjamin Button (2008)\n",
+            "**Movie 2:** Life of Pi (2012)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Conclusion"
+      ],
+      "metadata": {
+        "id": "bOCUQGwocd_7"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "- This notebook showcased efficient multi-task movie reviews using Gemma, TPUs and JAX for parallel inference tasks (character ID, plot, genre, and recommendations) all in a single prompt."
+      ],
+      "metadata": {
+        "id": "SBAzXojPcepV"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "ydttfHoAw_8s"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/Gemma/gemma_inference_on_tpu.ipynb
+++ b/Gemma/gemma_inference_on_tpu.ipynb
@@ -1,0 +1,466 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##### Copyright 2024 Google LLC."
+      ],
+      "metadata": {
+        "id": "zRN0MvYFIVmT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "metadata": {
+        "id": "kNIU45vmIl80"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Gemma Inference on TPUs\n",
+        "This notebook demonstrates how to leverage Google Colab's TPUs for inference with [Gemma](https://ai.google.dev/gemma) , an open-weights Large Language Model (LLM), using the [Flax](https://github.com/google/flax)."
+      ],
+      "metadata": {
+        "id": "9PcbvP7Lz1Pn"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/gemma-cookbook/blob/main/Gemma/gemma-data-parallel-inference-in-jax-tpu.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "</table>"
+      ],
+      "metadata": {
+        "id": "_CjBzJmRNm30"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Connect to a TPU\n",
+        "- To connect to a TPU v2, click on the button Connect TPU in the top right-hand corner of the screen."
+      ],
+      "metadata": {
+        "id": "09OSQCd5ebzP"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now you can see the TPU devices we have available:\n"
+      ],
+      "metadata": {
+        "id": "6wOtGTbWfKX1"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import jax\n",
+        "\n",
+        "jax.devices()"
+      ],
+      "metadata": {
+        "id": "TCXhNGCJexoK",
+        "outputId": "e33df2d7-52cf-4c18-bc9e-200a1d25ac57",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0),\n",
+              " TpuDevice(id=1, process_index=0, coords=(0,0,0), core_on_chip=1),\n",
+              " TpuDevice(id=2, process_index=0, coords=(1,0,0), core_on_chip=0),\n",
+              " TpuDevice(id=3, process_index=0, coords=(1,0,0), core_on_chip=1),\n",
+              " TpuDevice(id=4, process_index=0, coords=(0,1,0), core_on_chip=0),\n",
+              " TpuDevice(id=5, process_index=0, coords=(0,1,0), core_on_chip=1),\n",
+              " TpuDevice(id=6, process_index=0, coords=(1,1,0), core_on_chip=0),\n",
+              " TpuDevice(id=7, process_index=0, coords=(1,1,0), core_on_chip=1)]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 1
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LtzOe_3XY9R5"
+      },
+      "source": [
+        "## Installation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "- To install Gemma you need to use Python 3.10 or higher.\n",
+        "- Google Colab typically offers Python 3.6 or later versions as the default runtime environment."
+      ],
+      "metadata": {
+        "id": "b_42SyQifbJ2"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "iq2ebV_6YNiU",
+        "outputId": "bc462e8a-77ff-4e7b-dc96-7c46fdb49fe3",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting git+https://github.com/google-deepmind/gemma.git\n",
+            "  Cloning https://github.com/google-deepmind/gemma.git to /tmp/pip-req-build-vdzv6aiz\n",
+            "  Running command git clone --filter=blob:none --quiet https://github.com/google-deepmind/gemma.git /tmp/pip-req-build-vdzv6aiz\n",
+            "  Resolved https://github.com/google-deepmind/gemma.git to commit a24194737dcb54b7392091e9ba772aea1cb68ffb\n",
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "Requirement already satisfied: absl-py<3.0.0,>=2.1.0 in /usr/local/lib/python3.10/dist-packages (from gemma==1.0.0) (2.1.0)\n",
+            "Requirement already satisfied: flax>=0.8 in /usr/local/lib/python3.10/dist-packages (from gemma==1.0.0) (0.8.4)\n",
+            "Requirement already satisfied: sentencepiece<0.2.0,>=0.1.99 in /usr/local/lib/python3.10/dist-packages (from gemma==1.0.0) (0.1.99)\n",
+            "Requirement already satisfied: numpy>=1.22 in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (1.25.2)\n",
+            "Requirement already satisfied: jax>=0.4.19 in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (0.4.26)\n",
+            "Requirement already satisfied: msgpack in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (1.0.8)\n",
+            "Requirement already satisfied: optax in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (0.1.9)\n",
+            "Requirement already satisfied: orbax-checkpoint in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (0.4.4)\n",
+            "Requirement already satisfied: tensorstore in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (0.1.45)\n",
+            "Requirement already satisfied: rich>=11.1 in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (13.7.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.2 in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (4.12.2)\n",
+            "Requirement already satisfied: PyYAML>=5.4.1 in /usr/local/lib/python3.10/dist-packages (from flax>=0.8->gemma==1.0.0) (6.0.1)\n",
+            "Requirement already satisfied: ml-dtypes>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from jax>=0.4.19->flax>=0.8->gemma==1.0.0) (0.2.0)\n",
+            "Requirement already satisfied: opt-einsum in /usr/local/lib/python3.10/dist-packages (from jax>=0.4.19->flax>=0.8->gemma==1.0.0) (3.3.0)\n",
+            "Requirement already satisfied: scipy>=1.9 in /usr/local/lib/python3.10/dist-packages (from jax>=0.4.19->flax>=0.8->gemma==1.0.0) (1.11.4)\n",
+            "Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/local/lib/python3.10/dist-packages (from rich>=11.1->flax>=0.8->gemma==1.0.0) (3.0.0)\n",
+            "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/local/lib/python3.10/dist-packages (from rich>=11.1->flax>=0.8->gemma==1.0.0) (2.18.0)\n",
+            "Requirement already satisfied: chex>=0.1.7 in /usr/local/lib/python3.10/dist-packages (from optax->flax>=0.8->gemma==1.0.0) (0.1.86)\n",
+            "Requirement already satisfied: jaxlib>=0.1.37 in /usr/local/lib/python3.10/dist-packages (from optax->flax>=0.8->gemma==1.0.0) (0.4.26)\n",
+            "Requirement already satisfied: etils[epath,epy] in /usr/local/lib/python3.10/dist-packages (from orbax-checkpoint->flax>=0.8->gemma==1.0.0) (1.7.0)\n",
+            "Requirement already satisfied: nest_asyncio in /usr/local/lib/python3.10/dist-packages (from orbax-checkpoint->flax>=0.8->gemma==1.0.0) (1.6.0)\n",
+            "Requirement already satisfied: protobuf in /usr/local/lib/python3.10/dist-packages (from orbax-checkpoint->flax>=0.8->gemma==1.0.0) (3.20.3)\n",
+            "Requirement already satisfied: toolz>=0.9.0 in /usr/local/lib/python3.10/dist-packages (from chex>=0.1.7->optax->flax>=0.8->gemma==1.0.0) (0.12.1)\n",
+            "Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.10/dist-packages (from markdown-it-py>=2.2.0->rich>=11.1->flax>=0.8->gemma==1.0.0) (0.1.2)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from etils[epath,epy]->orbax-checkpoint->flax>=0.8->gemma==1.0.0) (2024.6.1)\n",
+            "Requirement already satisfied: importlib_resources in /usr/local/lib/python3.10/dist-packages (from etils[epath,epy]->orbax-checkpoint->flax>=0.8->gemma==1.0.0) (6.4.0)\n",
+            "Requirement already satisfied: zipp in /usr/local/lib/python3.10/dist-packages (from etils[epath,epy]->orbax-checkpoint->flax>=0.8->gemma==1.0.0) (3.19.2)\n",
+            "Requirement already satisfied: kaggle in /usr/local/lib/python3.10/dist-packages (1.6.14)\n",
+            "Requirement already satisfied: six>=1.10 in /usr/local/lib/python3.10/dist-packages (from kaggle) (1.16.0)\n",
+            "Requirement already satisfied: certifi>=2023.7.22 in /usr/local/lib/python3.10/dist-packages (from kaggle) (2024.7.4)\n",
+            "Requirement already satisfied: python-dateutil in /usr/local/lib/python3.10/dist-packages (from kaggle) (2.9.0.post0)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from kaggle) (2.31.0)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.10/dist-packages (from kaggle) (4.66.4)\n",
+            "Requirement already satisfied: python-slugify in /usr/local/lib/python3.10/dist-packages (from kaggle) (8.0.4)\n",
+            "Requirement already satisfied: urllib3 in /usr/local/lib/python3.10/dist-packages (from kaggle) (2.0.7)\n",
+            "Requirement already satisfied: bleach in /usr/local/lib/python3.10/dist-packages (from kaggle) (6.1.0)\n",
+            "Requirement already satisfied: webencodings in /usr/local/lib/python3.10/dist-packages (from bleach->kaggle) (0.5.1)\n",
+            "Requirement already satisfied: text-unidecode>=1.3 in /usr/local/lib/python3.10/dist-packages (from python-slugify->kaggle) (1.3)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->kaggle) (3.3.2)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->kaggle) (3.7)\n"
+          ]
+        }
+      ],
+      "source": [
+        "! pip install git+https://github.com/google-deepmind/gemma.git\n",
+        "! pip install --user kaggle"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QOzN-gxIYSB4"
+      },
+      "source": [
+        "## Downloading the Gemma Checkpoint\n",
+        "\n",
+        "Before using [Google Gemma](https://ai.google.dev/gemma) for the first time, you must request access to the model through Kaggle by setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), or completing the following steps:\n",
+        "\n",
+        "1. Log in to [Kaggle](https://www.kaggle.com) or create a new Kaggle account if you don't already have one.\n",
+        "1. Go to the [Gemma model card](https://www.kaggle.com/models/google/paligemma/), and click **Request Access**.\n",
+        "1. Complete the consent form and accept the terms and conditions.\n",
+        "\n",
+        "To generate a Kaggle API key, open your [**Settings** page in Kaggle](https://www.kaggle.com/settings) and click **Create New Token**. This triggers the download of a `kaggle.json` file containing your API credentials.\n",
+        "\n",
+        "Then, in Colab, select **Secrets** (🔑) in the left pane and add your Kaggle username and Kaggle API key. Store your username under desired name `KAGGLE_USERNAME` and your API key under the name `KAGGLE_KEY`.\n",
+        "\n",
+        "Set environment variables for Kaggle API credentials"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "likVQiEEYS5X"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from google.colab import userdata\n",
+        "\n",
+        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
+        "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "O-sxcasvESaM"
+      },
+      "outputs": [],
+      "source": [
+        "import kagglehub\n",
+        "\n",
+        "VARIANT = '2b-it' # @param ['2b', '2b-it', '7b', '7b-it'] {type:\"string\"}\n",
+        "weights_dir = kagglehub.model_download(f'google/gemma/Flax/{VARIANT}')\n",
+        "\n",
+        "ckpt_path = os.path.join(weights_dir, VARIANT)\n",
+        "vocab_path = os.path.join(weights_dir, 'tokenizer.model')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "-jpTUa1YESaM"
+      },
+      "outputs": [],
+      "source": [
+        "from gemma import params as params_lib\n",
+        "from gemma import sampler as sampler_lib\n",
+        "from gemma import transformer as transformer_lib\n",
+        "import sentencepiece as spm"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4fDQsC87ESaN"
+      },
+      "source": [
+        "## Start Generating with Your Model\n",
+        "\n",
+        "Load and prepare your LLM's checkpoint for use with Flax."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "cellView": "form",
+        "id": "57nMYQ4HESaN"
+      },
+      "outputs": [],
+      "source": [
+        "# Load parameters\n",
+        "params = params_lib.load_and_format_params(ckpt_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NWJ3UvHXESaN"
+      },
+      "source": [
+        "Load your tokenizer, which we'll construct using the [SentencePiece](https://github.com/google/sentencepiece) library."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "cellView": "form",
+        "id": "khXrjEF0ESaN",
+        "outputId": "80985c92-b56e-4dce-8713-6a40d7b66c2e",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 7
+        }
+      ],
+      "source": [
+        "vocab = spm.SentencePieceProcessor()\n",
+        "vocab.Load(vocab_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tCRtZMg0ESaN"
+      },
+      "source": [
+        "Use the `transformer_lib.TransformerConfig.from_params` function to automatically load the correct configuration from a checkpoint. Note that the vocabulary size is smaller than the number of input embeddings due to unused tokens in this release."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "cellView": "form",
+        "id": "7InOzQtcESaN"
+      },
+      "outputs": [],
+      "source": [
+        "transformer_config=transformer_lib.TransformerConfig.from_params(\n",
+        "    params,\n",
+        "    cache_size=1024  # Number of time steps in the transformer's cache\n",
+        ")\n",
+        "transformer = transformer_lib.Transformer(transformer_config)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KaU-X3_jESaN"
+      },
+      "source": [
+        "Finally, build a sampler on top of your model and your tokenizer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "cellView": "form",
+        "id": "bdstASGrESaN"
+      },
+      "outputs": [],
+      "source": [
+        "# Create a sampler with the right param shapes.\n",
+        "sampler = sampler_lib.Sampler(\n",
+        "    transformer=transformer,\n",
+        "    vocab=vocab,\n",
+        "    params=params['transformer'],\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "C1fLns-_ESaN"
+      },
+      "source": [
+        "You're ready to start sampling ! This sampler uses just-in-time compilation, so changing the input shape triggers recompilation, which can slow things down. For the fastest and most efficient results, keep your batch size consistent."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "cellView": "form",
+        "id": "qA0BhNQvESaN",
+        "outputId": "4bf0e9cf-b774-4ab4-ac27-455616c9dd15",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Prompt:\n",
+            "\n",
+            " Explain the phenomenon of a solar eclipse.\n",
+            " Answer:\n",
+            "\n",
+            "\n",
+            "A solar eclipse occurs when the Moon passes between the Sun and Earth, casting a shadow on Earth. This phenomenon is caused by the relative positions of the Moon, Sun, and Earth.\n",
+            "\n",
+            "**Here's a step-by-step explanation of how a solar eclipse occurs:**\n",
+            "\n",
+            "1. **New Moon:** The Moon is positioned between the Sun and Earth, and the Sun's rays are not directly visible from Earth.\n",
+            "2. **Waxing Crescent Phase:** As the Moon orbits the Sun, it gradually moves from the new moon phase to the waxing crescent phase. This means that the illuminated portion of the Moon is gradually increasing.\n",
+            "3. **First Quarter Phase:** When the Moon is at the first quarter phase, half of its face is illuminated.\n",
+            "4. **Waxing Gibbous Phase:** As the Moon continues to orbit the Sun, it moves further away from the Sun, and the illuminated portion of the Moon gradually increases to the waxing gibbous phase. This means that more and more of the Moon is illuminated.\n",
+            "5. **Full Moon:** When the Moon is at the full moon phase, the entire face of the Moon is illuminated.\n",
+            "6. **Waning Gibbous Phase:** As the Moon moves away from the Sun, it gradually moves back into the waning gibbous phase. This means that the illuminated portion of the Moon is gradually decreasing.\n",
+            "7. **Third Quarter Phase:** When the Moon is at the third quarter phase, half\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "input_batch = [\n",
+        "    \"\\n Explain the phenomenon of a solar eclipse.\",\n",
+        "  ]\n",
+        "\n",
+        "out_data = sampler(\n",
+        "    input_strings=input_batch,\n",
+        "    total_generation_steps=300,\n",
+        "  )\n",
+        "\n",
+        "for input_string, out_string in zip(input_batch, out_data.text):\n",
+        "  print(f\"Prompt:\\n{input_string}\\n Answer:\\n{out_string}\")\n",
+        "  print()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "TQoFmvkQ19AM"
+      },
+      "execution_count": 11,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "gpuType": "V28",
+      "name": "gemma_inference_on_tpu.ipynb"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "TPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
This PR adds two new tutorials:

- gemma_inference_on_tpu: Demonstrates basic inference with Gemma on TPUs.

- gemma-data-parallel-inference-in-jax-tpu: Showcases data-parallel inference for faster processing on TPUs using JAX.

CC: @gustheman 