### PR TITLE
fixing fine tuning workshop link in the main README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can find the Gemma models on GitHub, Hugging Face models, Kaggle, Google Clo
 ## Workshops and technical talks
 | Notebook                                                                                                                    | Description                                                                                                                                        |
 | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Workshop_How_to_Fine_tuning_Gemma.ipynb](Workshops/Workshop_How_to_Fine_tuning_Gemma.ipynb/Keras_Gemma_2_Quickstart.ipynb) | Recommended finetuning notebook for getting started                                                                                                |
+| [Workshop_How_to_Fine_tuning_Gemma.ipynb](Workshops/Workshop_How_to_Fine_tuning_Gemma.ipynb) | Recommended finetuning notebook for getting started                                                                                                |
 | [Self_extend_Gemma.ipynb](Gemma/Self_extend_Gemma.ipynb)                                                                    | Self-extend context window for Gemma in the I/O 2024 [Keras talk](https://www.youtube.com/watch?v=TV7qCk1dBWA)                                     |
 | [Gemma_control_vectors.ipynb](Gemma/Gemma_control_vectors.ipynb)                                                            | Implement [control vectors](https://arxiv.org/abs/2310.01405) with Gemma in the I/O 2024 [Keras talk](https://www.youtube.com/watch?v=TV7qCk1dBWA) |
 


### PR DESCRIPTION
fixing fine tuning workshop link in the main README file