### PR TITLE
Fix some PaliGemma 2 urls

### DIFF
--- a/PaliGemma_2/Finetune_PaliGemma_2_with_JAX.ipynb
+++ b/PaliGemma_2/Finetune_PaliGemma_2_with_JAX.ipynb
@@ -47,7 +47,7 @@
         "<a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/gemma-cookbook/blob/main/PaliGemma_2/Finetune_PaliGemma_2_with_JAX.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "</td>\n",
         "<td>\n",
-        "<a target=\"_blank\" href=\"https://github.com/google/google-gemini/gemma-cookbook/PaliGemma_2/Finetune_PaliGemma_2_with_JAX.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "<a target=\"_blank\" href=\"https://github.com/google-gemini/gemma-cookbook/blob/main/PaliGemma_2/Finetune_PaliGemma_2_with_JAX.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "</td>\n",
         "</table>\n"
       ]
@@ -105,7 +105,7 @@
         "Before using PaliGemma for the first time, you must request access to the model through Kaggle by completing the following steps:\n",
         "\n",
         "1. Log in to [Kaggle](https://www.kaggle.com), or create a new Kaggle account if you don't already have one.\n",
-        "1. Go to the [PaliGemma model card](https://www.kaggle.com/models/google/paligemma/) and click **Request Access**.\n",
+        "1. Go to the [PaliGemma model card](https://www.kaggle.com/models/google/paligemma-2) and click **Request Access**.\n",
         "1. Complete the consent form and accept the terms and conditions."
       ]
     },
@@ -359,7 +359,7 @@
       "source": [
         "### Download the model checkpoint\n",
         "\n",
-        "PaliGemma includes several model variations. For this tutorial, you'll use the base [JAX/FLAX PaliGemma 3B weight model](https://www.kaggle.com/models/google/paligemma/jax/paligemma-3b-pt-224).\n",
+        "PaliGemma includes several model variations. For this tutorial, you'll use the base [JAX/FLAX PaliGemma 3B weight model](https://www.kaggle.com/models/google/paligemma-2/jax/paligemma2-3b-pt-224).\n",
         "\n",
         "Download the `float16` version of the model checkpoint from Kaggle by running the following code. This process takes several minutes to complete."
       ]

--- a/PaliGemma_2/Finetune_PaliGemma_2_with_Keras.ipynb
+++ b/PaliGemma_2/Finetune_PaliGemma_2_with_Keras.ipynb
@@ -46,7 +46,7 @@
         "<a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/gemma-cookbook/blob/main/PaliGemma_2/Finetune_PaliGemma_2_with_Keras.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "</td>\n",
         "<td>\n",
-        "<a target=\"_blank\" href=\"https://github.com/google/google-gemini/gemma-cookbook/PaliGemma_2/Finetune_PaliGemma_2_with_Keras.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "<a target=\"_blank\" href=\"https://github.com/google-gemini/gemma-cookbook/blob/main/PaliGemma_2/Finetune_PaliGemma_2_with_Keras.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "</td>\n",
         "</table>"
       ]


### PR DESCRIPTION
These are minor changes

* Fix "Open in GitHub" link
* Fix some links pointing to PG1 in Keras