### PR TITLE
Fix broken link to 'Personal AI Code Assistant with Gemma' in`gemma-cookbook/Demos/README.md` #152

### DIFF
--- a/Demos/README.md
+++ b/Demos/README.md
@@ -6,7 +6,7 @@ This folder houses the companion notebooks for the "Build with AI" video series,
 | Folder                                                      | Description |
 | ----------------------------------------------------------- | ----------- |
 | [Business email assistant](business-email-assistant/) | [Business Email AI Assistant with Gemma](https://www.youtube.com/watch?v=YxhzozLH1Dk)<br>This project tackles the specific problem of extracting order information from emails to a bakery into structured data, so it can be quickly added to an order handling system. |
-| [Personal code assistant](personal-code-assistant/)   | [Personal AI Code Assistant with Gemma](https://www.youtube.com/watch?v=YxhzozLH1Dk)<br>This project shows you how to set up your own web service for hosting Gemma and connecting it to a Microsoft Visual Studio Code extension, to make using the model more convenient while coding. |
+| [Personal code assistant](personal-code-assistant/)   | [Personal AI Code Assistant with Gemma](https://www.youtube.com/watch?v=Zpo7UTvg_9E)<br>This project shows you how to set up your own web service for hosting Gemma and connecting it to a Microsoft Visual Studio Code extension, to make using the model more convenient while coding. |
 | [Spoken language tasks](spoken-language-tasks/)       | [Spoken Language AI Assistant with Gemma](https://www.youtube.com/watch?v=M4HGJehH4r0)<br>Learn how to tune a model to perform specific tasks in a specific language, without requiring extensive data or training time. |
 
 ## Mobile App Demo


### PR DESCRIPTION
The link to "Personal AI Code Assistant with Gemma" in [Demos/README.md](https://github.com/google-gemini/gemma-cookbook/tree/main/Demos) was incorrect and redirected to the wrong video. I updated it to the correct URL and verified that it now links to the intended video.

Old Link: (https://www.youtube.com/watch?v=YxhzozLH1Dk)
New Link: (https://www.youtube.com/watch?v=Zpo7UTvg_9E)

This PR resolves #152 .