### PR TITLE
Fix: Correct typos in CodeGemma notebooks

### DIFF
--- a/CodeGemma/[CodeGemma_1]Common_use_cases.ipynb
+++ b/CodeGemma/[CodeGemma_1]Common_use_cases.ipynb
@@ -81,7 +81,7 @@
       "source": [
         "### Configure your credentials\n",
         "\n",
-        "Add your your Kaggle credentials to the Colab Secrets manager to securely store it.\n",
+        "Add your Kaggle credentials to the Colab Secrets manager to securely store it.\n",
         "\n",
         "1. Open your Google Colab notebook and click on the 🔑 Secrets tab in the left panel. <img src=\"https://storage.googleapis.com/generativeai-downloads/images/secrets.jpg\" alt=\"The Secrets tab is found on the left panel.\" width=50%>\n",
         "2. Create new secrets: `KAGGLE_USERNAME` and `KAGGLE_KEY`\n",

--- a/CodeGemma/[CodeGemma_1]Finetune_with_SQL.ipynb
+++ b/CodeGemma/[CodeGemma_1]Finetune_with_SQL.ipynb
@@ -401,7 +401,7 @@
         "* a python script producing a SQL query\n",
         "* two separate scripts producing respectively, python and SQL code. \n",
         "\n",
-        "CodeGemma picked the the first option. Bear it in mind!"
+        "CodeGemma picked the first option. Bear it in mind!"
       ]
     },
     {
@@ -412,7 +412,7 @@
       "source": [
         "## Fine-tuning the model with LoRA\n",
         "\n",
-        "This section of the guide focuses on training your Large Language Model (LLM) to generate SQL code fron natural language. Here, we will explore the process of fine-tuning your model to enable it to produce high quality SQL queries."
+        "This section of the guide focuses on training your Large Language Model (LLM) to generate SQL code from natural language. Here, we will explore the process of fine-tuning your model to enable it to produce high quality SQL queries."
       ]
     },
     {
@@ -943,7 +943,7 @@
       "source": [
         "This time the model picked the second option providing two separate scripts producing respectively, python and SQL code! \n",
         "\n",
-        "The model knows we 'prefer' to get a SQL query now but it didn't forget the other porgramming languages it's been trained on."
+        "The model knows we 'prefer' to get a SQL query now but it didn't forget the other programming languages it's been trained on."
       ]
     },
     {
@@ -970,8 +970,8 @@
         "id": "HIDWBva0_SX4"
       },
       "source": [
-        "# Note: The token needs to have \"write\" permisssion\n",
-        "#       You can chceck it here:\n",
+        "# Note: The token needs to have \"write\" permission\n",
+        "#       You can check it here:\n",
         "#       https://huggingface.co/settings/tokens\n",
         "model.push_to_hub(\"my-codegemma-7-finetuned-model\")"
       ]
@@ -1008,9 +1008,9 @@
         "id": "0wEjhtJawvSr"
       },
       "source": [
-        "!model=\"google/codegemma-7b-it\" # ID of the model in Hugging Face hube\n",
+        "!model=\"google/codegemma-7b-it\" # ID of the model in Hugging Face hub\n",
         "# (you can use your own fine-tuned model from\n",
-        "# the prevous step)\n",
+        "# the previous step)\n",
         "!volume=$PWD/data               # Shared directory with the Docker container\n",
         "# to avoid downloading weights every run\n",
         "\n",


### PR DESCRIPTION
**Description:**

This PR corrects several minor typographical errors identified within the markdown/text cells of two CodeGemma notebooks.

**Files Changed:**

*   `CodeGemma/[CodeGemma_1]Common_use_cases.ipynb`
*   `CodeGemma/[CodeGemma_1]Finetune_with_SQL.ipynb`

**Types of Corrections:**

*   Corrected duplicated words (e.g., "your your", "the the").
*   Corrected spelling errors (e.g., "fron", "porgramming", "permisssion", "chceck", "hube", "prevous").