### PR TITLE
Fix: Add API key validation in proxy server

### DIFF
--- a/Demos/Gemma-on-Cloudrun/proxy_test.go
+++ b/Demos/Gemma-on-Cloudrun/proxy_test.go
@@ -13,6 +13,9 @@ import (
 	"testing"
 )
 
+const geminiApiKey = "some key"
+
+
 func TestProxy_GenerateContent(t *testing.T) {
 	expectedRequestBody := `{
 		"Stream":false,
@@ -88,6 +91,7 @@ func TestProxy_GenerateContent(t *testing.T) {
 	// 2. Set up the proxy server to point to the mock target
 	os.Setenv("PORT", "8085")                      // Use a test port
 	os.Setenv("OLLAMA_HOST", mockTargetServer.URL) // Ensure proxy targets the mock
+	os.Setenv("GEMINI_API_KEY", geminiApiKey)
 
 	// Start the proxy server in a goroutine
 	go main()
@@ -113,6 +117,7 @@ func TestProxy_GenerateContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating request: %v", err)
 	}
+	req.Header.Set("x-goog-api-key", geminiApiKey)
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -159,7 +164,7 @@ func TestProxy_GenerateContent(t *testing.T) {
 	var expected map[string]interface{}
 
 	if err := json.Unmarshal(respBodyBytes, &actual); err != nil {
-		t.Fatalf("failed to unmarshal actual response body: %v", err)
+		t.Fatalf("failed to unmarshal actual response body: %v", string(respBodyBytes))
 	}
 	if err := json.Unmarshal([]byte(expectedResponseBody), &expected); err != nil {
 		t.Fatalf("failed to unmarshal expected response body: %v", err)
@@ -169,3 +174,4 @@ func TestProxy_GenerateContent(t *testing.T) {
 		t.Errorf("ConvertResponseBody returned incorrect response body. Got: %v, Want: %v", actual, expected)
 	}
 }
+

--- a/Demos/Gemma-on-Cloudrun/proxy_test.go
+++ b/Demos/Gemma-on-Cloudrun/proxy_test.go
@@ -164,7 +164,7 @@ func TestProxy_GenerateContent(t *testing.T) {
 	var expected map[string]interface{}
 
 	if err := json.Unmarshal(respBodyBytes, &actual); err != nil {
-		t.Fatalf("failed to unmarshal actual response body: %v", string(respBodyBytes))
+		t.Fatalf("failed to unmarshal actual response body: %v", err)
 	}
 	if err := json.Unmarshal([]byte(expectedResponseBody), &expected); err != nil {
 		t.Fatalf("failed to unmarshal expected response body: %v", err)


### PR DESCRIPTION
Added API key validation for Gemma on Cloud run. 

* When deploying Gemma on Cloud run, an env var `GEMINI_API_KEY` needs to be provided. For users to get the api key, they can follow: https://ai.google.dev/gemini-api/docs/api-key 
* Once deployment is done, for every request that is made to Gemma on Cloud run, the request needs to contain the api key in either the query parameter(https://ai.google.dev/gemini-api/docs/api-key#send-gemini-api-request) or in the http header x-google-api-key, e.g. by using genAI SDK(https://pypi.org/project/google-genai/) 
* if the api key provided by the request doesn't match the value provided in the env var `GEMINI_API_KEY`, PERMISSION_DENIED error will be thrown. 