### PR TITLE
Fix(demo): correct bug in k-mail-replier's Gemini implementation

### DIFF
--- a/Demos/spoken-language-tasks/k-mail-replier/k_mail_replier/app.py
+++ b/Demos/spoken-language-tasks/k-mail-replier/k_mail_replier/app.py
@@ -51,7 +51,7 @@ def get_prompt():
 
 def get_test_email():
     try:
-        with open('data/email-001-ko.txt', 'r') as file:
+        with open('data/email-001-ko.txt', 'r', encoding='utf-8') as file:
             email_content = file.read()
     except FileNotFoundError:
         email_content = "Error: File not found!"

--- a/Demos/spoken-language-tasks/k-mail-replier/k_mail_replier/models/gemini.py
+++ b/Demos/spoken-language-tasks/k-mail-replier/k_mail_replier/models/gemini.py
@@ -23,8 +23,11 @@ def initialize_model():
     api_key = os.getenv('API_KEY')
     if not api_key:
         raise ValueError("API_KEY environment variable not found. Did you set it in your .env file?")
+    
     genai.configure(api_key=api_key)
-    return genai.GenerativeModel('gemini-1.5-flash')  # Return the initialized model
+    
+    model = genai.GenerativeModel('gemini-2.5-flash')
+    return model
 
 def create_message_processor():
     """Creates a message processor function with a persistent model."""


### PR DESCRIPTION
fixed bugs that prevented the Gemini model path in the `k-mail-replier` demo from running.

- fixed UnicodeDecodeError on Windows by adding encoding='utf-8 in app.py
- updated the model name from Available models list to fix a 404 not found api error

tested the app locally.