### PR TITLE
Fix formatting in Gemma 3 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Gemma is a family of lightweight, generative artificial intelligence (AI) open m
   * [Gemma 2](https://ai.google.dev/gemma/docs/core/model_card_2)\
     Higher-performing and more efficient, available in 2B, 9B, 27B parameter sizes
   * [Gemma 3](https://ai.google.dev/gemma/docs/core/model_card_3)\
-    Longer context window and handling text and image input, available in 1B, 4B, 12B and 27B parameter sizes
+    Longer context window and handling text and image input, available in 1B, 4B, 12B, 27B parameter sizes
   * [Gemma 3n](https://ai.google.dev/gemma/docs/gemma-3n/model_card) \
     Designed for efficient execution on low-resource devices. Handling text, image, video, and audio input, available in E2B and E4B parameter sizes
 * Gemma variants

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Gemma is a family of lightweight, generative artificial intelligence (AI) open m
   * [Gemma 2](https://ai.google.dev/gemma/docs/core/model_card_2)\
     Higher-performing and more efficient, available in 2B, 9B, 27B parameter sizes
   * [Gemma 3](https://ai.google.dev/gemma/docs/core/model_card_3)\
-    Longer context window and handling text and image input, available in 1B, 4B, 12B, 27B parameter sizes
+    Longer context window and handling text and image input, available in 1B, 4B, 12B, and 27B parameter sizes
   * [Gemma 3n](https://ai.google.dev/gemma/docs/gemma-3n/model_card) \
     Designed for efficient execution on low-resource devices. Handling text, image, video, and audio input, available in E2B and E4B parameter sizes
 * Gemma variants


### PR DESCRIPTION
Hi! I am a student and absolute beginner preparing for GSoC 2026. I noticed an inconsistency in how parameter sizes were listed for Gemma 3 compared to Gemma 2. I have updated the list to use consistent comma separation. This is my first contribution to the project.