### PR TITLE
fix: bump the cloud build time out to 2h for gemma models

### DIFF
--- a/Demos/Gemma-on-Cloudrun/cloudbuild.yaml
+++ b/Demos/Gemma-on-Cloudrun/cloudbuild.yaml
@@ -100,6 +100,7 @@ substitutions:
   _LOCATION: us
   _REPO: container
   
+timeout: 7200s # 120 minutes, to allow for building large models.
 
 options:
   # Automatically make substitutions available as environment variables to scripts.


### PR DESCRIPTION
Previously the default time out is 1h. I see the build failed due to timeout starting from Feb. 