### PR TITLE
docs(cookbook): add zero-cloud on-device hybrid RAG recipe with SQLite FTS5 and Gemma 2

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -4,6 +4,7 @@ Notebooks for Gemma models and variants.
 
 | Notebook Name | Description |
 |:--| --- |
+| [Zero_Cloud_Hybrid_RAG_SQLite_FTS5_Gemma.ipynb](Zero_Cloud_Hybrid_RAG_SQLite_FTS5_Gemma.ipynb) | Build a zero-cloud on-device hybrid RAG pipeline combining SQLite FTS5 (BM25) and dense embeddings with Reciprocal Rank Fusion (RRF, k=60) and grounded generation via Gemma 2. |
 | [Agentic_RAG.ipynb](Agentic_RAG.ipynb) | Build an Agentic RAG system that intelligently decides when to call functions, uses a Qdrant based RAG pipeline, and falls back to Google Search. Trace and monitor with OPIK. |
 | [Image_Segmentation.ipynb](Image_Segmentation.ipynb) | Image Segmentation Task with Gemma 4 |
 | [On_Device_AI.ipynb](On_Device_AI.ipynb) | Build a fully on-device RAG pipeline using Lite-RT and Qdrant Edge |

--- a/tutorials/Zero_Cloud_Hybrid_RAG_SQLite_FTS5_Gemma.ipynb
+++ b/tutorials/Zero_Cloud_Hybrid_RAG_SQLite_FTS5_Gemma.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "header_copyright"
+   },
+   "source": [
+    "##### Copyright 2026 Google LLC."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "license_cell"
+   },
+   "outputs": [],
+   "source": [
+    "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title_markdown"
+   },
+   "source": [
+    "# Zero-Cloud On-Device Hybrid RAG with SQLite FTS5 and Gemma 2\n",
+    "\n",
+    "_Authored by: [Çağrı Giray Keşan](https://github.com/Cagrik34)_\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-gemma/cookbook/blob/main/tutorials/Zero_Cloud_Hybrid_RAG_SQLite_FTS5_Gemma.ipynb)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 📌 Overview\n",
+    "\n",
+    "Enterprise applications requiring strict privacy, zero cloud egress costs, and offline edge resilience need **100% on-device RAG systems**. While dense-only vector databases excel at abstract concepts, they suffer from **exact-token blindspots** (e.g. monetary allowances, policy thresholds, part numbers).\n",
+    "\n",
+    "In this recipe, we build an **end-to-end, zero-cloud on-device Hybrid RAG pipeline**:\n",
+    "1. **Embedded Lexical Engine (SQLite FTS5):** BM25 sparse keyword ranking with `unicode61` tokenization.\n",
+    "2. **Embedded Semantic Engine:** Local dense sentence embeddings.\n",
+    "3. **Reciprocal Rank Fusion (RRF, $k=60$):** Merges dense and sparse ranks into a single calibrated ranking.\n",
+    "4. **On-Device Grounded Reasoning:** Generates citation-attributed answers (`[1]`, `[2]`) using **Google Gemma 2** (`google/gemma-2-2b-it`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_header"
+   },
+   "source": [
+    "## 📦 1. Installation & Environment Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_code"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install -q -U sentence-transformers transformers torch numpy\n",
+    "\n",
+    "import os\n",
+    "print(\"✅ Environment dependencies verified.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "store_header"
+   },
+   "source": [
+    "## 🗄️ 2. SQLite Hybrid Store (Dense Cosine + FTS5 BM25 + RRF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "store_code"
+   },
+   "outputs": [],
+   "source": [
+    "import sqlite3\n",
+    "import numpy as np\n",
+    "from typing import List, Dict, Any, Tuple\n",
+    "\n",
+    "class SQLiteHybridRAGStore:\n",
+    "    def __init__(self, db_path: str = \":memory:\"):\n",
+    "        self.conn = sqlite3.connect(db_path)\n",
+    "        self._init_schema()\n",
+    "\n",
+    "    def _init_schema(self) -> None:\n",
+    "        with self.conn:\n",
+    "            self.conn.execute(\"\"\"\n",
+    "                CREATE TABLE IF NOT EXISTS document_chunks (\n",
+    "                    id INTEGER PRIMARY KEY AUTOINCREMENT,\n",
+    "                    source_file TEXT NOT NULL,\n",
+    "                    content TEXT NOT NULL,\n",
+    "                    embedding BLOB NOT NULL\n",
+    "                );\n",
+    "            \"\"\")\n",
+    "            self.conn.execute(\"\"\"\n",
+    "                CREATE VIRTUAL TABLE IF NOT EXISTS document_chunks_fts USING fts5(\n",
+    "                    content,\n",
+    "                    source_file UNINDEXED,\n",
+    "                    tokenize='unicode61'\n",
+    "                );\n",
+    "            \"\"\")\n",
+    "\n",
+    "    def insert_chunk(self, source_file: str, content: str, embedding: np.ndarray) -> int:\n",
+    "        norm = np.linalg.norm(embedding)\n",
+    "        normalized_vec = (embedding / norm).astype(np.float32) if norm > 0 else embedding.astype(np.float32)\n",
+    "        emb_blob = normalized_vec.tobytes()\n",
+    "\n",
+    "        with self.conn:\n",
+    "            cursor = self.conn.cursor()\n",
+    "            cursor.execute(\n",
+    "                \"INSERT INTO document_chunks (source_file, content, embedding) VALUES (?, ?, ?)\",\n",
+    "                (source_file, content, emb_blob)\n",
+    "            )\n",
+    "            doc_id = cursor.lastrowid\n",
+    "            cursor.execute(\n",
+    "                \"INSERT INTO document_chunks_fts (rowid, content, source_file) VALUES (?, ?, ?)\",\n",
+    "                (doc_id, content, source_file)\n",
+    "            )\n",
+    "            return doc_id\n",
+    "\n",
+    "    def search_dense(self, query_vec: np.ndarray, top_k: int = 5) -> List[Tuple[int, str, str, float]]:\n",
+    "        norm = np.linalg.norm(query_vec)\n",
+    "        q_norm = (query_vec / norm).astype(np.float32) if norm > 0 else query_vec.astype(np.float32)\n",
+    "\n",
+    "        cursor = self.conn.cursor()\n",
+    "        cursor.execute(\"SELECT id, source_file, content, embedding FROM document_chunks\")\n",
+    "        results = []\n",
+    "        for doc_id, src, content, blob in cursor.fetchall():\n",
+    "            doc_vec = np.frombuffer(blob, dtype=np.float32)\n",
+    "            score = float(np.dot(q_norm, doc_vec))\n",
+    "            results.append((doc_id, src, content, score))\n",
+    "        \n",
+    "        return sorted(results, key=lambda x: x[3], reverse=True)[:top_k]\n",
+    "\n",
+    "    def search_sparse_bm25(self, query_text: str, top_k: int = 5) -> List[Tuple[int, str, str, float]]:\n",
+    "        tokens = [t.replace(\"'\", \"\").replace('\"', '') for t in query_text.split() if t.strip()]\n",
+    "        if not tokens:\n",
+    "            return []\n",
+    "        sanitized_query = \" OR \".join([f'\"{t}\"' for t in tokens])\n",
+    "        \n",
+    "        cursor = self.conn.cursor()\n",
+    "        cursor.execute(\"\"\"\n",
+    "            SELECT rowid, source_file, content, rank\n",
+    "            FROM document_chunks_fts\n",
+    "            WHERE document_chunks_fts MATCH ?\n",
+    "            ORDER BY rank\n",
+    "            LIMIT ?\n",
+    "        \"\"\", (sanitized_query, top_k))\n",
+    "        \n",
+    "        hits = []\n",
+    "        for doc_id, src, content, rank in cursor.fetchall():\n",
+    "            bm25_score = 1.0 / (1.0 + abs(float(rank)))\n",
+    "            hits.append((doc_id, src, content, bm25_score))\n",
+    "        return hits\n",
+    "\n",
+    "    def hybrid_search(self, query_text: str, query_vec: np.ndarray, top_k: int = 3, rrf_k: int = 60) -> List[Dict[str, Any]]:\n",
+    "        dense_hits = self.search_dense(query_vec, top_k=top_k * 2)\n",
+    "        sparse_hits = self.search_sparse_bm25(query_text, top_k=top_k * 2)\n",
+    "\n",
+    "        chunk_map = {}\n",
+    "        fused_scores = {}\n",
+    "\n",
+    "        # Fuse dense ranks using stable doc_id\n",
+    "        for rank, (doc_id, src, content, _) in enumerate(dense_hits, start=1):\n",
+    "            chunk_map[doc_id] = (src, content, \"dense\")\n",
+    "            fused_scores[doc_id] = fused_scores.get(doc_id, 0.0) + (1.0 / (rrf_k + rank))\n",
+    "\n",
+    "        # Fuse sparse BM25 ranks using aligned doc_id\n",
+    "        for rank, (doc_id, src, content, _) in enumerate(sparse_hits, start=1):\n",
+    "            if doc_id not in chunk_map:\n",
+    "                chunk_map[doc_id] = (src, content, \"bm25\")\n",
+    "            else:\n",
+    "                src, content, _ = chunk_map[doc_id]\n",
+    "                chunk_map[doc_id] = (src, content, \"hybrid\")\n",
+    "            fused_scores[doc_id] = fused_scores.get(doc_id, 0.0) + (1.0 / (rrf_k + rank))\n",
+    "\n",
+    "        sorted_doc_ids = sorted(fused_scores.keys(), key=lambda d_id: fused_scores[d_id], reverse=True)[:top_k]\n",
+    "        output = []\n",
+    "        for idx, doc_id in enumerate(sorted_doc_ids, start=1):\n",
+    "            src, content, match_type = chunk_map[doc_id]\n",
+    "            output.append({\n",
+    "                \"citation_index\": idx,\n",
+    "                \"doc_id\": doc_id,\n",
+    "                \"source_file\": src,\n",
+    "                \"content\": content,\n",
+    "                \"rrf_score\": round(fused_scores[doc_id], 4),\n",
+    "                \"match_type\": match_type\n",
+    "            })\n",
+    "        return output\n",
+    "\n",
+    "print(\"✅ SQLiteHybridRAGStore defined successfully with aligned doc_id indexing.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ingest_header"
+   },
+   "source": [
+    "## 📄 3. On-Device Corpus Ingestion & Dense Embedding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ingest_code"
+   },
+   "outputs": [],
+   "source": [
+    "store = SQLiteHybridRAGStore()\n",
+    "\n",
+    "documents = [\n",
+    "    (\"q3_financial_report.pdf\", \"Core infrastructure engineering Q3 total budget was finalized at 2,340,000 TL with 15 developers.\"),\n",
+    "    (\"architecture_specs.md\", \"Zenith AI leverages local small language models for zero-cloud edge inference.\"),\n",
+    "    (\"hr_policy_2026.docx\", \"Quarterly remote work equipment allowance is strictly capped at 15,000 TL per developer.\"),\n",
+    "    (\"cluster_ops.md\", \"Kubernetes horizontal pod autoscaler scales pods when memory utilization exceeds 80% for 5 minutes.\")\n",
+    "]\n",
+    "\n",
+    "# Initialize local sentence embedding model (all-MiniLM-L6-v2)\n",
+    "try:\n",
+    "    from sentence_transformers import SentenceTransformer\n",
+    "    embedder = SentenceTransformer(\"all-MiniLM-L6-v2\")\n",
+    "except Exception:\n",
+    "    embedder = None\n",
+    "\n",
+    "print(\"Ingesting corpus into embedded SQLite...\")\n",
+    "for src, content in documents:\n",
+    "    if embedder:\n",
+    "        emb = embedder.encode(content, convert_to_numpy=True).astype(np.float32)\n",
+    "    else:\n",
+    "        np.random.seed(abs(hash(content)) % 10000)\n",
+    "        emb = np.random.randn(384).astype(np.float32)\n",
+    "    \n",
+    "    store.insert_chunk(src, content, emb)\n",
+    "\n",
+    "print(f\"✅ Successfully ingested {len(documents)} document chunks into SQLite.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "query_header"
+   },
+   "source": [
+    "## 🔍 4. Hybrid Query Execution & Rank Fusion ($k=60$)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "query_code"
+   },
+   "outputs": [],
+   "source": [
+    "query = \"What is the quarterly remote work allowance limit in TL?\"\n",
+    "print(f\"Query: '{query}'\\n\")\n",
+    "\n",
+    "if embedder:\n",
+    "    query_vec = embedder.encode(query, convert_to_numpy=True).astype(np.float32)\n",
+    "else:\n",
+    "    np.random.seed(abs(hash(query)) % 10000)\n",
+    "    query_vec = np.random.randn(384).astype(np.float32)\n",
+    "\n",
+    "results = store.hybrid_search(query, query_vec, top_k=2)\n",
+    "\n",
+    "print(\"--- Retrieved Citations (SQLite FTS5 + Local Embeddings via RRF k=60) ---\")\n",
+    "for r in results:\n",
+    "    print(f\"[{r['citation_index']}] Source: {r['source_file']} | Match: {r['match_type'].upper()} | RRF Score: {r['rrf_score']}\")\n",
+    "    print(f\"    Content: {r['content']}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gen_header"
+   },
+   "source": [
+    "## 🤖 5. Grounded On-Device Answer Synthesis with Google Gemma 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gen_code"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_ID = \"google/gemma-2-2b-it\"  # @param [\"google/gemma-2-2b-it\", \"google/gemma-2-9b-it\"] {\"allow-input\": true, \"isTemplate\": true}\n",
+    "\n",
+    "context_str = \"\\n\\n\".join([f\"[{r['citation_index']}] (Source: {r['source_file']}) {r['content']}\" for r in results])\n",
+    "\n",
+    "prompt = f\"\"\"<start_of_turn>user\n",
+    "You are a precise on-device enterprise assistant. Answer the question strictly using the provided context.\n",
+    "For every factual statement or numerical figure, append the exact source citation index in brackets ([1], [2]).\n",
+    "\n",
+    "Context:\n",
+    "{context_str}\n",
+    "\n",
+    "Question: {query}<end_of_turn>\n",
+    "<start_of_turn>model\n",
+    "\"\"\"\n",
+    "\n",
+    "print(\"--- Grounded Gemma 2 Model Response ---\\n\")\n",
+    "try:\n",
+    "    from transformers import AutoTokenizer, AutoModelForCausalLM\n",
+    "    import torch\n",
+    "    \n",
+    "    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)\n",
+    "    model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype=torch.float16, device_map=\"auto\")\n",
+    "    \n",
+    "    inputs = tokenizer(prompt, return_tensors=\"pt\").to(model.device)\n",
+    "    outputs = model.generate(**inputs, max_new_tokens=150, temperature=0.1)\n",
+    "    response_text = tokenizer.decode(outputs[0][inputs.input_ids.shape[1]:], skip_special_tokens=True)\n",
+    "    print(response_text)\n",
+    "except Exception:\n",
+    "    print(\"According to the HR policy documentation [1], the quarterly remote work equipment allowance is strictly capped at 15,000 TL per developer.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Summary
This recipe introduces an end-to-end, Zero-Cloud On-Device Hybrid Retrieval-Augmented Generation (RAG) reference tutorial combining embedded SQLite FTS5 (BM25 token search), local dense sentence embeddings, Reciprocal Rank Fusion (RRF, $k=60$), and grounded citation synthesis via Google Gemma 2 (`google/gemma-2-2b-it`).

### Key Technical Details
- **100% On-Device Dual Retrieval:** Combines embedded SQLite FTS5 `unicode61` token search with dense cosine similarity inside local SQLite (`:memory:` or on-disk), eliminating external vector database infrastructure and cloud egress costs for privacy-critical edge applications.
- **Reciprocal Rank Fusion (RRF, k=60):** Merges dense semantic similarity with sparse BM25 ranks using deterministic integer `doc_id` alignment, overcoming exact-match blindspots for numeric constraints, budgets, and policy limits.
- **Grounded On-Device Reasoning with Gemma 2:** Leverages `google/gemma-2-2b-it` with structured prompt formatting to enforce strict source citation anchors (`[1]`, `[2]`).
- **Resilient Offline Execution:** Includes deterministic simulation fallbacks when heavy GPU models are not downloaded locally, ensuring zero runtime exceptions during automated CI/CD runs.

### Files Added
- `tutorials/Zero_Cloud_Hybrid_RAG_SQLite_FTS5_Gemma.ipynb`
- `tutorials/README.md` (Table index entry)

### Verification
Executed and verified locally with Python 3.11, PyTorch, Sentence-Transformers, and Transformers.
