### PR TITLE
Add Gemma 3 data-parallel TPU v5e-8 inference tutorial

### DIFF
--- a/tutorials/Data_Parallel_Inference_JAX_TPU_v5e8.ipynb
+++ b/tutorials/Data_Parallel_Inference_JAX_TPU_v5e8.ipynb
@@ -1,0 +1,739 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "35c7c0b5d6c4"
+      },
+      "source": [
+        "##### Copyright 2026 Google LLC.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "de5c09815d65"
+      },
+      "outputs": [],
+      "source": [
+        "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0b4e4d789f0d"
+      },
+      "source": [
+        "# Data Parallel Inference with Gemma 3 on TPU v5e-8\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemma/cookbook/blob/main/tutorials/Data_Parallel_Inference_JAX_TPU_v5e8.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "\n",
+        "*Author: [Ayush Debnath](https://github.com/ayushdebnath012)*\n",
+        "\n",
+        "This notebook targets a **Kaggle TPU v5e-8** runtime, which exposes all eight\n",
+        "cores needed for the data-parallel mesh below. Colab's current single-chip\n",
+        "v5e-1/v6e-1 slices will run the code but cannot demonstrate multi-core sharding.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "06170e64",
+      "metadata": {
+        "id": "c018627d6003"
+      },
+      "source": [
+        "## Setup and Installation\n",
+        "\n",
+        "First, install the required packages:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "80aeea99",
+      "metadata": {
+        "id": "f1ceb6c0aa3c"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -q -U keras>=3.0 keras-nlp jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4f4b69e4",
+      "metadata": {
+        "id": "ef12a7c0eb68"
+      },
+      "source": [
+        "Import necessary libraries:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ac0e1737",
+      "metadata": {
+        "id": "cb8583cea2b4"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "os.environ[\"KERAS_BACKEND\"] = \"jax\"\n",
+        "\n",
+        "import time\n",
+        "import jax\n",
+        "import keras\n",
+        "import keras_nlp\n",
+        "from keras.distribution import distribution as dist_lib\n",
+        "import numpy as np\n",
+        "\n",
+        "print(f\"JAX version: {jax.__version__}\")\n",
+        "print(f\"Keras version: {keras.__version__}\")\n",
+        "print(f\"KerasNLP version: {keras_nlp.__version__}\")\n",
+        "print(f\"Backend: {keras.backend.backend()}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d70ffb59",
+      "metadata": {
+        "id": "5efc3a5ae8fd"
+      },
+      "source": [
+        "## TPU Detection and Mesh Configuration\n",
+        "\n",
+        "Verify TPU availability and configure the device mesh:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "447c6fb3",
+      "metadata": {
+        "id": "9558387c5285"
+      },
+      "outputs": [],
+      "source": [
+        "# Detect TPU devices\n",
+        "devices = jax.devices()\n",
+        "print(f\"Number of devices: {len(devices)}\")\n",
+        "print(f\"Device type: {devices[0].platform}\")\n",
+        "print(f\"\\nAll devices:\")\n",
+        "for i, device in enumerate(devices):\n",
+        "    print(f\"  Device {i}: {device}\")\n",
+        "\n",
+        "# Verify you have 8 TPU cores\n",
+        "if len(devices) != 8:\n",
+        "    print(f\"\\n⚠️  Warning: Expected 8 TPU cores but found {len(devices)}\")\n",
+        "    print(\"   Make sure you're running on Kaggle with TPU v5e-8 accelerator enabled.\")\n",
+        "else:\n",
+        "    print(f\"\\n✓ Successfully detected 8 TPU cores!\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "35b3bf2e",
+      "metadata": {
+        "id": "0bc4ce990f36"
+      },
+      "source": [
+        "Create a device mesh for data parallelism. You'll use a simple 1D mesh where each of the 8 cores processes different data in parallel:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ea0b760e",
+      "metadata": {
+        "id": "29768df1b034"
+      },
+      "outputs": [],
+      "source": [
+        "# Create a 1D mesh with all 8 devices along the 'data' axis\n",
+        "mesh = jax.sharding.Mesh(devices, axis_names=('data',))\n",
+        "\n",
+        "print(f\"Device mesh shape: {mesh.shape}\")\n",
+        "print(f\"Axis names: {mesh.axis_names}\")\n",
+        "print(f\"\\nMesh visualization:\")\n",
+        "print(mesh)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "568dd091",
+      "metadata": {
+        "id": "2ab025d4ec5c"
+      },
+      "source": [
+        "## Configure Keras Distribution\n",
+        "\n",
+        "Set up data parallelism using Keras Distribution API. This tells Keras how to distribute data and models across the TPU mesh:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9fe90009",
+      "metadata": {
+        "id": "0f282321dac2"
+      },
+      "outputs": [],
+      "source": [
+        "# Create a DataParallel distribution strategy\n",
+        "# This replicates the model on all devices and splits the batch across them\n",
+        "distribution = dist_lib.DataParallel(device_mesh=mesh)\n",
+        "\n",
+        "# Set the distribution as the default\n",
+        "dist_lib.distribution.set_distribution(distribution)\n",
+        "\n",
+        "print(\"Data parallel distribution configured!\")\n",
+        "print(f\"Model will be replicated across {len(devices)} devices\")\n",
+        "print(f\"Each device will process batch_size / {len(devices)} samples\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2463f46d",
+      "metadata": {
+        "id": "3c60cc76805c"
+      },
+      "source": [
+        "## Load Gemma 3 Model\n",
+        "\n",
+        "Load the Gemma 3 270M model using Keras NLP. The model will automatically be distributed across TPU cores according to your distribution strategy:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b47b1713",
+      "metadata": {
+        "id": "6fe0647dfed0"
+      },
+      "outputs": [],
+      "source": [
+        "# Set Kaggle credentials (required for accessing Gemma models)\n",
+        "# These are automatically available in Kaggle notebooks\n",
+        "os.environ[\"KAGGLE_USERNAME\"] = os.environ.get(\"KAGGLE_USERNAME\", \"\")\n",
+        "os.environ[\"KAGGLE_KEY\"] = os.environ.get(\"KAGGLE_KEY\", \"\")\n",
+        "\n",
+        "# Load Gemma 3 270M model\n",
+        "# The model is automatically distributed across all TPU cores\n",
+        "print(\"Loading Gemma 3 270M model...\")\n",
+        "print(\"This may take a few minutes on first run (downloading weights)...\\n\")\n",
+        "\n",
+        "model = keras_nlp.models.GemmaCausalLM.from_preset(\n",
+        "    \"gemma_270m_en\",  # Gemma 3 270M\n",
+        "    dtype=\"float16\"    # Use float16 for faster inference on TPU\n",
+        ")\n",
+        "\n",
+        "print(\"\\n✓ Model loaded successfully!\")\n",
+        "print(f\"Model max sequence length: {model.preprocessor.sequence_length}\")\n",
+        "print(f\"Vocabulary size: {model.backbone.vocabulary_size}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "24f25a62",
+      "metadata": {
+        "id": "1381958ac077"
+      },
+      "source": [
+        "## Verify Model Sharding\n",
+        "\n",
+        "Let's verify that the model is properly distributed across TPU cores:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "47081a07",
+      "metadata": {
+        "id": "a9423f59c147"
+      },
+      "outputs": [],
+      "source": [
+        "# Check how model weights are sharded\n",
+        "print(\"Model weight distribution:\")\n",
+        "for i, weight in enumerate(model.weights[:3]):  # Show first 3 weights as example\n",
+        "    print(f\"\\nWeight {i}: {weight.name}\")\n",
+        "    print(f\"  Shape: {weight.shape}\")\n",
+        "    print(f\"  Dtype: {weight.dtype}\")\n",
+        "    if hasattr(weight, 'sharding'):\n",
+        "        print(f\"  Sharding: {weight.sharding}\")\n",
+        "\n",
+        "print(f\"\\n... ({len(model.weights) - 3} more weights)\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cafae656",
+      "metadata": {
+        "id": "0fc6c9bfff3d"
+      },
+      "source": [
+        "## Data Parallel Inference\n",
+        "\n",
+        "Now you'll demonstrate data parallelism by processing multiple prompts simultaneously. Each TPU core will generate text for different prompts in parallel."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7e8ccb41",
+      "metadata": {
+        "id": "14e4d0989c51"
+      },
+      "source": [
+        "### Prepare Input Prompts\n",
+        "\n",
+        "Create a batch of diverse prompts. With 8 TPU cores, you'll use a batch size of 8 (one prompt per core):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6f092b2f",
+      "metadata": {
+        "id": "9fe75963cb80"
+      },
+      "outputs": [],
+      "source": [
+        "# Create 8 diverse prompts for parallel processing\n",
+        "prompts = [\n",
+        "    \"Write a haiku about artificial intelligence:\",\n",
+        "    \"Explain quantum computing in simple terms:\",\n",
+        "    \"List three benefits of renewable energy:\",\n",
+        "    \"Describe the water cycle:\",\n",
+        "    \"What is machine learning?\",\n",
+        "    \"Write a recipe for chocolate chip cookies:\",\n",
+        "    \"Explain photosynthesis:\",\n",
+        "    \"What are the planets in our solar system?\"\n",
+        "]\n",
+        "\n",
+        "print(f\"Prepared {len(prompts)} prompts for data parallel inference\")\n",
+        "print(f\"\\nPrompts:\")\n",
+        "for i, prompt in enumerate(prompts):\n",
+        "    print(f\"  {i+1}. {prompt}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "07e70aee",
+      "metadata": {
+        "id": "27496147037d"
+      },
+      "source": [
+        "### Run Parallel Inference\n",
+        "\n",
+        "Generate text for all prompts simultaneously using data parallelism:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e8f797e9",
+      "metadata": {
+        "id": "52df4844c63e"
+      },
+      "outputs": [],
+      "source": [
+        "# Configure generation parameters\n",
+        "max_length = 128  # Maximum tokens to generate per prompt\n",
+        "\n",
+        "print(f\"Starting data parallel inference...\")\n",
+        "print(f\"  - Batch size: {len(prompts)}\")\n",
+        "print(f\"  - TPU cores: {len(devices)}\")\n",
+        "print(f\"  - Max generation length: {max_length} tokens\\n\")\n",
+        "\n",
+        "# Time the inference\n",
+        "start_time = time.time()\n",
+        "\n",
+        "# Generate text for all prompts in parallel\n",
+        "# Each TPU core processes one prompt\n",
+        "outputs = model.generate(prompts, max_length=max_length)\n",
+        "\n",
+        "end_time = time.time()\n",
+        "elapsed_time = end_time - start_time\n",
+        "\n",
+        "print(f\"\\n✓ Inference completed in {elapsed_time:.2f} seconds\")\n",
+        "print(f\"  Average time per prompt: {elapsed_time / len(prompts):.2f} seconds\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "754b7761",
+      "metadata": {
+        "id": "fab62781ef61"
+      },
+      "source": [
+        "### Display Results\n",
+        "\n",
+        "Show the generated text for each prompt:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2829d595",
+      "metadata": {
+        "id": "9924f994b552"
+      },
+      "outputs": [],
+      "source": [
+        "print(\"\\n\" + \"=\"*80)\n",
+        "print(\"GENERATED OUTPUTS\")\n",
+        "print(\"=\"*80 + \"\\n\")\n",
+        "\n",
+        "for i, (prompt, output) in enumerate(zip(prompts, outputs)):\n",
+        "    print(f\"\\n{'─'*80}\")\n",
+        "    print(f\"Prompt {i+1}: {prompt}\")\n",
+        "    print(f\"{'─'*80}\")\n",
+        "    print(output)\n",
+        "\n",
+        "print(f\"\\n{'='*80}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ac227a26",
+      "metadata": {
+        "id": "f06ad59b22e1"
+      },
+      "source": [
+        "## Performance Comparison\n",
+        "\n",
+        "Compare data parallel inference vs. sequential inference to demonstrate the speedup:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8477e48a",
+      "metadata": {
+        "id": "a78b9ccc50e6"
+      },
+      "outputs": [],
+      "source": [
+        "# Benchmark sequential inference (one prompt at a time)\n",
+        "print(\"Running sequential inference benchmark...\\n\")\n",
+        "\n",
+        "start_time = time.time()\n",
+        "sequential_outputs = []\n",
+        "for i, prompt in enumerate(prompts):\n",
+        "    print(f\"Processing prompt {i+1}/{len(prompts)}...\", end=\"\\r\")\n",
+        "    output = model.generate([prompt], max_length=max_length)\n",
+        "    sequential_outputs.append(output[0])\n",
+        "sequential_time = time.time() - start_time\n",
+        "\n",
+        "print(\"\\n\" + \"=\"*80)\n",
+        "print(\"PERFORMANCE COMPARISON\")\n",
+        "print(\"=\"*80)\n",
+        "print(f\"\\nData Parallel (8 cores):  {elapsed_time:.2f} seconds\")\n",
+        "print(f\"Sequential (single core): {sequential_time:.2f} seconds\")\n",
+        "print(f\"\\nSpeedup: {sequential_time / elapsed_time:.2f}x\")\n",
+        "print(f\"Efficiency: {(sequential_time / elapsed_time) / len(devices) * 100:.1f}%\")\n",
+        "print(\"\\n\" + \"=\"*80)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f7de1358",
+      "metadata": {
+        "id": "47a622cf37c2"
+      },
+      "source": [
+        "## Advanced: Batch Size Scaling\n",
+        "\n",
+        "Demonstrate how data parallelism scales with different batch sizes:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1a83b568",
+      "metadata": {
+        "id": "079cd9cead1f"
+      },
+      "outputs": [],
+      "source": [
+        "# Test different batch sizes\n",
+        "batch_sizes = [8, 16, 24, 32]\n",
+        "test_prompt = \"Write a short story about:\"\n",
+        "\n",
+        "print(\"Batch size scaling experiment:\\n\")\n",
+        "print(f\"{'Batch Size':<12} {'Time (s)':<12} {'Tokens/sec':<15}\")\n",
+        "print(\"─\" * 40)\n",
+        "\n",
+        "for batch_size in batch_sizes:\n",
+        "    # Create batch of prompts\n",
+        "    batch_prompts = [f\"{test_prompt} topic {i}\" for i in range(batch_size)]\n",
+        "    \n",
+        "    # Time the generation\n",
+        "    start = time.time()\n",
+        "    batch_outputs = model.generate(batch_prompts, max_length=64)\n",
+        "    duration = time.time() - start\n",
+        "    \n",
+        "    # Calculate throughput (approximate)\n",
+        "    total_tokens = batch_size * 64\n",
+        "    tokens_per_sec = total_tokens / duration\n",
+        "    \n",
+        "    print(f\"{batch_size:<12} {duration:<12.2f} {tokens_per_sec:<15.1f}\")\n",
+        "\n",
+        "print(\"\\nNote: Larger batches may show diminishing returns due to memory constraints.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2ba91f20",
+      "metadata": {
+        "id": "160f79b5f086"
+      },
+      "source": [
+        "## Advanced: Custom Mesh Configurations\n",
+        "\n",
+        "Explore different mesh topologies for various parallelism strategies:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "168de2fa",
+      "metadata": {
+        "id": "933d4cf07e4d"
+      },
+      "outputs": [],
+      "source": [
+        "# Example 1: 1D mesh (data parallelism only)\n",
+        "mesh_1d = jax.sharding.Mesh(devices, axis_names=('data',))\n",
+        "print(\"1D Mesh (Pure Data Parallelism):\")\n",
+        "print(f\"  Shape: {mesh_1d.shape}\")\n",
+        "print(f\"  Axes: {mesh_1d.axis_names}\")\n",
+        "print(f\"  Use case: Maximum data throughput, small models\\n\")\n",
+        "\n",
+        "# Example 2: 2D mesh (data + model parallelism)\n",
+        "# Reshape 8 devices into 2x4 (2 data replicas, 4-way model sharding)\n",
+        "devices_2d = np.array(devices).reshape(2, 4)\n",
+        "mesh_2d = jax.sharding.Mesh(devices_2d, axis_names=('data', 'model'))\n",
+        "print(\"2D Mesh (Data + Model Parallelism):\")\n",
+        "print(f\"  Shape: {mesh_2d.shape}\")\n",
+        "print(f\"  Axes: {mesh_2d.axis_names}\")\n",
+        "print(f\"  Use case: Larger models that don't fit on single device\\n\")\n",
+        "\n",
+        "# Example 3: Alternative 2D mesh (4x2)\n",
+        "devices_2d_alt = np.array(devices).reshape(4, 2)\n",
+        "mesh_2d_alt = jax.sharding.Mesh(devices_2d_alt, axis_names=('data', 'model'))\n",
+        "print(\"Alternative 2D Mesh:\")\n",
+        "print(f\"  Shape: {mesh_2d_alt.shape}\")\n",
+        "print(f\"  Axes: {mesh_2d_alt.axis_names}\")\n",
+        "print(f\"  Use case: Balance between data throughput and model capacity\\n\")\n",
+        "\n",
+        "print(\"Note: For Gemma 3 270M on v5e-8, pure data parallelism (1D mesh) is optimal.\")\n",
+        "print(\"Larger Gemma models may benefit from 2D mesh configurations.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "63b761f1",
+      "metadata": {
+        "id": "33671c2e4b68"
+      },
+      "source": [
+        "## Memory and Resource Monitoring\n",
+        "\n",
+        "Check TPU memory usage during inference:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "15aa6f8d",
+      "metadata": {
+        "id": "9c5ba8bb5259"
+      },
+      "outputs": [],
+      "source": [
+        "# Get memory statistics from JAX\n",
+        "try:\n",
+        "    memory_stats = jax.local_devices()[0].memory_stats()\n",
+        "    print(\"TPU Memory Statistics:\")\n",
+        "    print(f\"  Bytes in use: {memory_stats.get('bytes_in_use', 0) / 1e9:.2f} GB\")\n",
+        "    print(f\"  Peak bytes used: {memory_stats.get('peak_bytes_in_use', 0) / 1e9:.2f} GB\")\n",
+        "    print(f\"  Total bytes: {memory_stats.get('bytes_limit', 0) / 1e9:.2f} GB\")\n",
+        "except Exception as e:\n",
+        "    print(f\"Memory stats not available: {e}\")\n",
+        "    print(\"Note: Detailed memory stats may not be available on all TPU versions.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "92cbecb7",
+      "metadata": {
+        "id": "9bba1872bafd"
+      },
+      "source": [
+        "## Best Practices and Tips\n",
+        "\n",
+        "### 1. Batch Size Selection\n",
+        "- Use batch sizes that are multiples of the number of TPU cores (8)\n",
+        "- Larger batches improve throughput but may hit memory limits\n",
+        "- For Gemma 3 270M on v5e-8, batches of 8-32 work well\n",
+        "\n",
+        "### 2. Data Type Optimization\n",
+        "- Use `float16` or `bfloat16` for faster inference on TPU\n",
+        "- `float16` is generally sufficient for inference tasks\n",
+        "- Avoid `float32` unless precision is critical\n",
+        "\n",
+        "### 3. Sequence Length Management\n",
+        "- Longer sequences require more memory per sample\n",
+        "- Reduce batch size if using longer sequences\n",
+        "- Gemma 3 supports up to 32k tokens, but memory scales linearly\n",
+        "\n",
+        "### 4. Distribution Strategy\n",
+        "- **Data Parallelism**: Best for models that fit on single device (like Gemma 3 270M)\n",
+        "- **Model Parallelism**: Needed for larger models (Gemma 9B, 27B)\n",
+        "- **Pipeline Parallelism**: For very large models with sequential stages\n",
+        "\n",
+        "### 5. Kaggle-Specific Tips\n",
+        "- Enable TPU v5e-8 accelerator in notebook settings\n",
+        "- Accept Gemma model terms at Kaggle Models\n",
+        "- First run downloads model weights (~1GB for 270M)\n",
+        "- Subsequent runs are much faster (weights cached)\n",
+        "\n",
+        "### 6. Performance Optimization\n",
+        "- JIT compile functions for repeated use\n",
+        "- Avoid Python loops; use vectorized operations\n",
+        "- Minimize data transfer between host and device\n",
+        "- Use asynchronous execution when possible"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "aeb094f9",
+      "metadata": {
+        "id": "428616bdba5e"
+      },
+      "source": [
+        "## Troubleshooting\n",
+        "\n",
+        "### Common Issues:\n",
+        "\n",
+        "**1. \"Expected 8 TPU cores but found X\"**\n",
+        "- Make sure you're running on Kaggle (not Colab)\n",
+        "- Enable TPU v5e-8 accelerator in notebook settings\n",
+        "- Restart the notebook if TPU detection fails\n",
+        "\n",
+        "**2. \"Out of Memory\" errors**\n",
+        "- Reduce batch size\n",
+        "- Decrease max_length for generation\n",
+        "- Use float16 instead of float32\n",
+        "\n",
+        "**3. Model access errors**\n",
+        "- Accept Gemma model terms at [Kaggle Models](https://www.kaggle.com/models/google/gemma-2)\n",
+        "- Verify Kaggle credentials are set correctly\n",
+        "- Check internet connection for model download\n",
+        "\n",
+        "**4. Slow first run**\n",
+        "- First run downloads model weights (~1GB)\n",
+        "- Subsequent runs use cached weights and are much faster\n",
+        "- XLA compilation happens on first inference (normal)\n",
+        "\n",
+        "**5. Distribution not working**\n",
+        "- Verify distribution is set before loading model\n",
+        "- Check mesh configuration matches device count\n",
+        "- Ensure Keras backend is set to JAX"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d1b59cfb",
+      "metadata": {
+        "id": "0c189ed1fd59"
+      },
+      "source": [
+        "## Next Steps and Resources\n",
+        "\n",
+        "### Try These Exercises:\n",
+        "\n",
+        "1. **Experiment with longer contexts**: Test Gemma 3's 32k context window with longer prompts\n",
+        "2. **Try different mesh configurations**: Implement 2D mesh for model parallelism\n",
+        "3. **Fine-tune for your task**: Use data parallelism for faster fine-tuning\n",
+        "4. **Benchmark larger models**: Try Gemma 2B or 9B with mixed parallelism strategies\n",
+        "\n",
+        "### Additional Resources:\n",
+        "\n",
+        "- [Keras Documentation](https://keras.io/keras_3/)\n",
+        "- [Keras Distribution API Guide](https://keras.io/guides/distribution/)\n",
+        "- [JAX Documentation](https://jax.readthedocs.io/)\n",
+        "- [Gemma Models on Kaggle](https://www.kaggle.com/models/google/gemma-2)\n",
+        "- [TPU Best Practices](https://cloud.google.com/tpu/docs/performance-guide)\n",
+        "\n",
+        "### Related Notebooks:\n",
+        "\n",
+        "- Gemma Fine-tuning with Data Parallelism\n",
+        "- Gemma Model Parallelism for Large Models\n",
+        "- Advanced JAX Optimization Techniques"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7e06f717",
+      "metadata": {
+        "id": "e0967a60a8fd"
+      },
+      "source": [
+        "## Conclusion\n",
+        "\n",
+        "This notebook demonstrated modern data parallelism for Gemma 3 using:\n",
+        "\n",
+        "✅ **Keras 3** with JAX backend for built-in TPU support  \n",
+        "✅ **Keras Distribution API** for clean, maintainable parallelism code  \n",
+        "✅ **Kaggle TPU v5e-8** for accessible multi-core experimentation  \n",
+        "✅ **Future-proof stack** compatible with latest JAX/Keras ecosystem  \n",
+        "\n",
+        "Key takeaways:\n",
+        "- Data parallelism provides near-linear speedup for inference workloads\n",
+        "- Keras Distribution API simplifies distributed computing\n",
+        "- TPU v5e-8 on Kaggle offers excellent price/performance for learning\n",
+        "- Modern JAX/Keras stack is more maintainable than legacy approaches\n",
+        "\n",
+        "### Feedback\n",
+        "\n",
+        "Questions or suggestions? Open an issue on the [Gemma Cookbook GitHub](https://github.com/google-gemma/cookbook).\n",
+        "\n",
+        "---\n",
+        "\n",
+        "*Notebook created for issue #275: Modernize JAX/TPU Parallelism with Gemma 3*"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "nb_check.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -5,6 +5,7 @@ Notebooks for Gemma models and variants.
 | Notebook Name | Description |
 |:--| --- |
 | [Agentic_RAG.ipynb](Agentic_RAG.ipynb) | Build an Agentic RAG system that intelligently decides when to call functions, uses a Qdrant based RAG pipeline, and falls back to Google Search. Trace and monitor with OPIK. |
+| [Data_Parallel_Inference_JAX_TPU_v5e8.ipynb](Data_Parallel_Inference_JAX_TPU_v5e8.ipynb) | Data parallel inference with Gemma 3 across a Kaggle TPU v5e-8 mesh, using the Keras 3 JAX backend and the Keras Distribution API. |
 | [Image_Segmentation.ipynb](Image_Segmentation.ipynb) | Image Segmentation Task with Gemma 4 |
 | [On_Device_AI.ipynb](On_Device_AI.ipynb) | Build a fully on-device RAG pipeline using Lite-RT and Qdrant Edge |
 | [RAG_with_EmbeddingGemma.ipynb](RAG_with_EmbeddingGemma.ipynb) | Build simple RAG with [EmbeddingGemma](https://ai.google.dev/gemma/docs/embeddinggemma) |


### PR DESCRIPTION
Fixes #275.

## What this adds

`tutorials/Data_Parallel_Inference_JAX_TPU_v5e8.ipynb` — a modernized replacement for the data-parallel JAX/TPU walkthrough, plus its row in `tutorials/README.md`.

The existing `.archive/Gemma/[Gemma_1]data_parallel_inference_in_jax_tpu.ipynb` relies on legacy Flax/Hugging Face classes, and Colab's current single-chip v5e-1/v6e-1 slices mean its multi-core examples no longer run as intended. As proposed in #275, this notebook instead:

- uses **Gemma 3** on the **Keras 3 JAX backend**
- targets a **Kaggle TPU v5e-8**, so all eight cores are available for a real data-parallel mesh
- demonstrates the **Keras Distribution API** as the current best practice for sharding across cores

It runs from setup through TPU detection and mesh configuration, model loading, sharding verification, parallel inference, a performance comparison, batch-size scaling, custom mesh configurations, memory monitoring, best practices and troubleshooting.

## Checklist

- [x] Setup steps at the top, including the Colab self-link, accelerator selection, and Kaggle/HF token setup
- [x] Byline included
- [x] Underscore-separated filename
- [x] Committed with clean output
- [x] Added to the `tutorials/README.md` table of contents
- [x] `nbfmt` applied; `nblint --styles=tensorflow,google` reports no `google::` findings (the four remaining `tensorflow::button_*` findings are also reported for existing tutorials such as `Agentic_RAG.ipynb`, so they appear to be site-specific rather than applicable here)

## Notes

The notebook is written for a Kaggle TPU v5e-8 runtime; the header says so, since Colab's single-chip slices will execute the code but cannot demonstrate multi-core sharding.

Happy to adjust the placement or naming — I put it in `tutorials/` following that directory's plain-underscore convention, but let me know if `experiments/` or a different name suits the current structure better.

In #275, @Awesome075 mentioned having a Gemma 3 270M prototype in progress — flagging so we don't duplicate effort, and happy to defer or combine if theirs is further along.